### PR TITLE
Add API response tracing

### DIFF
--- a/myskoda/__init__.py
+++ b/myskoda/__init__.py
@@ -20,7 +20,7 @@ from .models import (
     user,
 )
 from .mqtt import Mqtt
-from .myskoda import MySkoda
+from .myskoda import TRACE_CONFIG, MySkoda
 from .rest_api import RestApi
 from .vehicle import Vehicle
 
@@ -44,4 +44,5 @@ __all__ = [
     "Mqtt",
     "Vehicle",
     "user",
+    "TRACE_CONFIG",
 ]

--- a/myskoda/cli.py
+++ b/myskoda/cli.py
@@ -24,7 +24,7 @@ from .models.common import (
     OpenState,
 )
 from .models.operation_request import OperationName, OperationStatus
-from .myskoda import MySkoda
+from .myskoda import TRACE_CONFIG, MySkoda
 
 
 @click.group()
@@ -40,7 +40,10 @@ async def cli(ctx: Context, username: str, password: str, verbose: bool) -> None
     ctx.obj["username"] = username
     ctx.obj["password"] = password
 
-    session = ClientSession()
+    trace_configs = []
+    if verbose:
+        trace_configs.append(TRACE_CONFIG)
+    session = ClientSession(trace_configs=trace_configs)
     myskoda = MySkoda(session)
     await myskoda.connect(username, password)
 


### PR DESCRIPTION
See https://docs.aiohttp.org/en/stable/client_advanced.html#client-tracing

Example:

```
❯ poetry run myskoda --user foo@gmail.com --password 'bar' --verbose auth
...
2024-09-21 19:19:55 WALLY myskoda.myskoda[14829] DEBUG Trace: GET https://mysmob.api.connect.skoda-auto.cz/api/v1/users - response: 200 (643 bytes) {"id":"123","email":"fabrice.devaux@gmail.com","firstName":"Foo","lastName":"Bar","nickname":"Foo","country":"BE","preferredLanguage":"en","phone":"+12345","billingAddress":{"country":"BE","city":"Stormwind","street":"Foo","houseNumber":"1","zipCode":"90218"},"capabilities":[{"id":"SPIN_MANAGEMENT"},{"id":"THIRD_PARTY_OFFERS"},{"id":"MARKETING_CONSENT"}],"preferredContactChannel":"MARKETING_BLOCKADES:EMAIL","profilePictureUrl":"https://mysmob.api.connect.skoda-auto.cz/api/v1/users/123/profile-picture?etag=123"}
```