### PR TITLE
Adjust PredictiveMaintenanceSettings

### DIFF
--- a/myskoda/cli.py
+++ b/myskoda/cli.py
@@ -259,7 +259,9 @@ async def maintenance(ctx: Context, vin: str) -> None:
         print(f"     {address.country} ({address.country_code})")
     if maintenance.predictive_maintenance:
         print(f"{colored("email:", "blue")} {maintenance.predictive_maintenance.setting.email}")
-        print(f"{colored("phone:", "blue")} {maintenance.predictive_maintenance.setting.phone}")
+        print(
+            f"{colored("phone:", "blue")} {maintenance.predictive_maintenance.setting.phone or '-'}"
+        )
 
 
 @cli.command()

--- a/myskoda/models/maintenance.py
+++ b/myskoda/models/maintenance.py
@@ -53,11 +53,12 @@ class CommunicationChannel(StrEnum):
 @dataclass
 class PredictiveMaintenanceSettings(DataClassORJSONMixin):
     email: str
-    phone: str
-    preferred_channel: CommunicationChannel = field(
-        metadata=field_options(alias="preferredChannel")
-    )
     service_activated: bool = field(metadata=field_options(alias="serviceActivated"))
+    phone: str = field(default=None)
+    preferred_channel: CommunicationChannel = field(
+        default=None,
+        metadata=field_options(alias="preferredChannel"),
+    )
 
 
 @dataclass


### PR DESCRIPTION
Make phone and preferred_channel optional in predictive maintenance setting:

- Phone is not always filled in. Fixes my issue (https://github.com/skodaconnect/homeassistant-myskoda/issues/34)
- Preferred Channel is also not always present. Fixes issue (https://github.com/skodaconnect/homeassistant-myskoda/issues/33)

Also made the "phone" print nicer when using the CLI (prints a "-" instead of None)