### PR TITLE
(bug) Fix charging model to include errors

### DIFF
--- a/myskoda/models/charging.py
+++ b/myskoda/models/charging.py
@@ -89,7 +89,8 @@ class Battery(DataClassORJSONMixin):
 @dataclass
 class ChargingStatus(DataClassORJSONMixin):
     battery: Battery
-    state: ChargingState
+    state: ChargingState | None
+    errors: list[ChargingError] | None
     charging_rate_in_kilometers_per_hour: float = field(
         metadata=field_options(alias="chargingRateInKilometersPerHour")
     )


### PR DESCRIPTION
When there is a charging error, the charging state is not always included in the API reply. Make the field optional
Also, include the charging error as we find them

Fixes https://github.com/skodaconnect/homeassistant-myskoda/issues/36