### PR TITLE
MQTT flag in CLI

### DIFF
--- a/myskoda/cli.py
+++ b/myskoda/cli.py
@@ -8,7 +8,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from functools import update_wrapper
 from logging import DEBUG, INFO
-from typing import ParamSpec, TypeVar
+from typing import TypeVar
 
 import asyncclick as click
 import coloredlogs
@@ -31,7 +31,6 @@ from .models.operation_request import OperationName, OperationStatus
 from .myskoda import TRACE_CONFIG, MySkoda
 
 R = TypeVar("R")
-P = ParamSpec("P")
 
 
 def mqtt_required(func: Callable[..., Awaitable[R]]) -> Callable[..., Awaitable[Awaitable[R]]]:

--- a/myskoda/cli.py
+++ b/myskoda/cli.py
@@ -5,10 +5,7 @@ poetry run python3 -m myskoda.cli
 """
 
 import asyncio
-from collections.abc import Awaitable, Callable
-from functools import update_wrapper
 from logging import DEBUG, INFO
-from typing import TypeVar
 
 import asyncclick as click
 import coloredlogs
@@ -30,35 +27,21 @@ from .models.common import (
 from .models.operation_request import OperationName, OperationStatus
 from .myskoda import TRACE_CONFIG, MySkoda
 
-R = TypeVar("R")
-
-
-def mqtt_required(func: Callable[..., Awaitable[R]]) -> Callable[..., Awaitable[Awaitable[R]]]:
-    """Enable MQTT before connecting to MySkoda."""
-
-    @click.pass_context
-    async def new_func(ctx: Context, *args, **kwargs) -> Awaitable[R]:  # noqa: ANN002, ANN003
-        ctx.obj["myskoda"].enable_mqtt = True
-        return await ctx.invoke(func, *args, **kwargs)
-
-    return update_wrapper(new_func, func)
-
-
-async def ensure_connected(ctx: Context) -> None:
-    """Ensure that MySkoda is connected, enabling MQTT if necessary."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    username: str = ctx.obj["username"]
-    password: str = ctx.obj["password"]
-    await myskoda.connect(username, password)
-
 
 @click.group()
 @click.version_option()
 @click.option("username", "--user", help="Username used for login.", required=True)
 @click.option("password", "--password", help="Password used for login.", required=True)
 @click.option("verbose", "--verbose", help="Enable verbose logging.", is_flag=True)
+@click.option("disable_mqtt", "--disable-mqtt", help="Do not connect to MQTT.", is_flag=True)
 @click.pass_context
-async def cli(ctx: Context, username: str, password: str, verbose: bool) -> None:
+async def cli(
+    ctx: Context,
+    username: str,
+    password: str,
+    verbose: bool,
+    disable_mqtt: bool,
+) -> None:
     """Interact with the MySkoda API."""
     coloredlogs.install(level=DEBUG if verbose else INFO)
     ctx.ensure_object(dict)
@@ -69,7 +52,8 @@ async def cli(ctx: Context, username: str, password: str, verbose: bool) -> None
     if verbose:
         trace_configs.append(TRACE_CONFIG)
     session = ClientSession(trace_configs=trace_configs)
-    myskoda = MySkoda(session, enable_mqtt=False)
+    myskoda = MySkoda(session, enable_mqtt=not disable_mqtt)
+    await myskoda.connect(username, password)
 
     ctx.obj["myskoda"] = myskoda
     ctx.obj["session"] = session
@@ -77,12 +61,13 @@ async def cli(ctx: Context, username: str, password: str, verbose: bool) -> None
 
 @cli.result_callback()
 @click.pass_context
-async def disconnect(
+async def disconnect(  # noqa: PLR0913
     ctx: Context,
     result: None,  # noqa: ARG001
     username: str,  # noqa: ARG001
     password: str,  # noqa: ARG001
     verbose: bool,  # noqa: ARG001
+    disable_mqtt: bool,  # noqa: ARG001
 ) -> None:
     myskoda: MySkoda = ctx.obj["myskoda"]
     session: ClientSession = ctx.obj["session"]
@@ -95,7 +80,6 @@ async def disconnect(
 @click.pass_context
 async def auth(ctx: Context) -> None:
     """Extract the auth token."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     print(myskoda.get_auth_token())
 
@@ -104,7 +88,6 @@ async def auth(ctx: Context) -> None:
 @click.pass_context
 async def list_vehicles(ctx: Context) -> None:
     """Print a list of all vehicle identification numbers associated with the account."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
 
     print(f"{colored("vehicles:", "blue")}")
@@ -117,7 +100,6 @@ async def list_vehicles(ctx: Context) -> None:
 @click.pass_context
 async def info(ctx: Context, vin: str) -> None:
     """Print info for the specified vin."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     info = await myskoda.get_info(vin)
 
@@ -145,7 +127,6 @@ async def info(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def status(ctx: Context, vin: str) -> None:
     """Print current status for the specified vin."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     status = await myskoda.get_status(vin)
 
@@ -165,7 +146,6 @@ async def status(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def air_conditioning(ctx: Context, vin: str) -> None:
     """Print current status about air conditioning."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     ac = await myskoda.get_air_conditioning(vin)
 
@@ -195,7 +175,6 @@ async def air_conditioning(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def positions(ctx: Context, vin: str) -> None:
     """Print the vehicle's current position."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     positions = await myskoda.get_positions(vin)
 
@@ -220,7 +199,6 @@ async def positions(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def health(ctx: Context, vin: str) -> None:
     """Print the vehicle's mileage."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     health = await myskoda.get_health(vin)
 
@@ -233,7 +211,6 @@ async def health(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def charging(ctx: Context, vin: str) -> None:
     """Print the vehicle's current charging state."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     charging = await myskoda.get_charging(vin)
 
@@ -273,7 +250,6 @@ async def charging(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def maintenance(ctx: Context, vin: str) -> None:
     """Print the vehicle's maintenance information."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     maintenance = await myskoda.get_maintenance(vin)
 
@@ -307,7 +283,6 @@ async def maintenance(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def driving_range(ctx: Context, vin: str) -> None:
     """Print the vehicle's estimated driving range information."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     driving_range = await myskoda.get_driving_range(vin)
 
@@ -324,7 +299,6 @@ async def driving_range(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def user(ctx: Context) -> None:
     """Print information about currently logged in user."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     user = await myskoda.get_user()
 
@@ -338,7 +312,6 @@ async def user(ctx: Context) -> None:
 @click.pass_context
 async def trip_statistics(ctx: Context, vin: str) -> None:
     """Print the last trip statics."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     stats = await myskoda.get_trip_statistics(vin)
 
@@ -360,11 +333,9 @@ async def trip_statistics(ctx: Context, vin: str) -> None:
 
 @cli.command()
 @click.argument("operation", type=click.Choice(OperationName))  # pyright: ignore [reportArgumentType]
-@mqtt_required
 @click.pass_context
 async def wait_for_operation(ctx: Context, operation: OperationName) -> None:
     """Wait for the operation with the specified name to complete."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
 
     print(f"Waiting for an operation {colored(operation,"green")} to start and complete...")
@@ -374,11 +345,9 @@ async def wait_for_operation(ctx: Context, operation: OperationName) -> None:
 
 
 @cli.command()
-@mqtt_required
 @click.pass_context
 async def subscribe(ctx: Context) -> None:
     """Connect to the MQTT broker and listen for messages."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
 
     def on_event(event: Event) -> None:
@@ -419,7 +388,6 @@ async def subscribe(ctx: Context) -> None:
 @click.option("temperature", "--temperature", type=float, required=True)
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
-@mqtt_required
 @click.pass_context
 async def start_air_conditioning(
     ctx: Context,
@@ -428,7 +396,6 @@ async def start_air_conditioning(
     vin: str,
 ) -> None:
     """Start the air conditioning with the provided target temperature in °C."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     async with asyncio.timeout(timeout):
         await myskoda.start_air_conditioning(vin, temperature)
@@ -437,11 +404,9 @@ async def start_air_conditioning(
 @cli.command()
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
-@mqtt_required
 @click.pass_context
 async def stop_air_conditioning(ctx: Context, timeout: float, vin: str) -> None:  # noqa: ASYNC109
     """Stop the air conditioning."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     async with asyncio.timeout(timeout):
         await myskoda.stop_air_conditioning(vin)
@@ -451,7 +416,6 @@ async def stop_air_conditioning(ctx: Context, timeout: float, vin: str) -> None:
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
 @click.option("temperature", "--temperature", type=float, required=True)
-@mqtt_required
 @click.pass_context
 async def set_target_temperature(
     ctx: Context,
@@ -460,7 +424,6 @@ async def set_target_temperature(
     temperature: float,
 ) -> None:
     """Set the air conditioning's target temperature in °C."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     async with asyncio.timeout(timeout):
         await myskoda.set_target_temperature(vin, temperature)
@@ -469,11 +432,9 @@ async def set_target_temperature(
 @cli.command()
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
-@mqtt_required
 @click.pass_context
 async def start_window_heating(ctx: Context, timeout: float, vin: str) -> None:  # noqa: ASYNC109
     """Start heating both the front and rear window."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     async with asyncio.timeout(timeout):
         await myskoda.start_window_heating(vin)
@@ -482,11 +443,9 @@ async def start_window_heating(ctx: Context, timeout: float, vin: str) -> None: 
 @cli.command()
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
-@mqtt_required
 @click.pass_context
 async def stop_window_heating(ctx: Context, timeout: float, vin: str) -> None:  # noqa: ASYNC109
     """Stop heating both the front and rear window."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     async with asyncio.timeout(timeout):
         await myskoda.stop_window_heating(vin)
@@ -496,11 +455,9 @@ async def stop_window_heating(ctx: Context, timeout: float, vin: str) -> None:  
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
 @click.option("limit", "--limit", type=float, required=True)
-@mqtt_required
 @click.pass_context
 async def set_charge_limit(ctx: Context, timeout: float, vin: str, limit: int) -> None:  # noqa: ASYNC109
     """Set the maximum charge limit in percent."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     async with asyncio.timeout(timeout):
         await myskoda.set_charge_limit(vin, limit)
@@ -510,11 +467,9 @@ async def set_charge_limit(ctx: Context, timeout: float, vin: str, limit: int) -
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
 @click.option("enabled", "--enabled", type=bool, required=True)
-@mqtt_required
 @click.pass_context
 async def set_battery_care_mode(ctx: Context, timeout: float, vin: str, enabled: bool) -> None:  # noqa: ASYNC109
     """Enable or disable the battery care mode."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     async with asyncio.timeout(timeout):
         await myskoda.set_battery_care_mode(vin, enabled)
@@ -524,11 +479,9 @@ async def set_battery_care_mode(ctx: Context, timeout: float, vin: str, enabled:
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
 @click.option("enabled", "--enabled", type=bool, required=True)
-@mqtt_required
 @click.pass_context
 async def set_reduced_current_limit(ctx: Context, timeout: float, vin: str, enabled: bool) -> None:  # noqa: ASYNC109
     """Enable reducing the current limit by which the car is charged."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     async with asyncio.timeout(timeout):
         await myskoda.set_reduced_current_limit(vin, enabled)
@@ -537,11 +490,9 @@ async def set_reduced_current_limit(ctx: Context, timeout: float, vin: str, enab
 @cli.command()
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
-@mqtt_required
 @click.pass_context
 async def wakeup(ctx: Context, timeout: float, vin: str) -> None:  # noqa: ASYNC109
     """Wake the vehicle up. Can be called maximum three times a day."""
-    await ensure_connected(ctx)
     myskoda: MySkoda = ctx.obj["myskoda"]
     async with asyncio.timeout(timeout):
         await myskoda.wakeup(vin)

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -9,7 +9,7 @@ from asyncio import gather
 from collections.abc import Awaitable, Callable
 from ssl import SSLContext
 from types import SimpleNamespace
-from typing import ParamSpec, TypeVar
+from typing import TypeVar
 
 from aiohttp import ClientSession, TraceConfig, TraceRequestEndParams
 
@@ -47,14 +47,13 @@ async def trace_response(
 
 
 R = TypeVar("R")
-P = ParamSpec("P")
 
 
 def check_mqtt_enabled(func: Callable[..., Awaitable[R]]) -> Callable[..., Awaitable[R | None]]:
     """Check if MQTT is enabled before calling the function and otherwise log an error."""
 
     @functools.wraps(func)
-    async def wrapper(self: MySkoda, *args, **kwargs) -> R | None:  # noqa: ANN002, ANN003
+    async def wrapper(self: "MySkoda", *args, **kwargs) -> R | None:  # noqa: ANN002, ANN003
         if self.enable_mqtt:
             return await func(self, *args, **kwargs)
         _LOGGER.error(f"MQTT is disabled, cannot perform {func.__name__}")

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -50,11 +50,11 @@ R = TypeVar("R")
 P = ParamSpec("P")
 
 
-def check_mqtt_enabled(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+def check_mqtt_enabled(func: Callable[..., Awaitable[R]]) -> Callable[..., Awaitable[R | None]]:
     """Check if MQTT is enabled before calling the function and otherwise log an error."""
 
     @functools.wraps(func)
-    async def wrapper(self: MySkoda, *args: P.args, **kwargs: P.kwargs) -> R:
+    async def wrapper(self: MySkoda, *args, **kwargs) -> R | None:  # noqa: ANN002, ANN003
         if self.enable_mqtt:
             return await func(self, *args, **kwargs)
         _LOGGER.error(f"MQTT is disabled, cannot perform {func.__name__}")
@@ -97,7 +97,7 @@ class MySkoda:
         _LOGGER.debug("Myskoda ready.")
 
     @check_mqtt_enabled
-    def subscribe(self, callback: Callable[[Event], None | Awaitable[None]]) -> None:
+    async def subscribe(self, callback: Callable[[Event], None | Awaitable[None]]) -> None:
         """Listen for events emitted by MySkoda's MQTT broker."""
         self.mqtt.subscribe(callback)
 

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -3,11 +3,13 @@
 This class provides all methods to operate on the API and MQTT broker.
 """
 
+import functools
 import logging
 from asyncio import gather
 from collections.abc import Awaitable, Callable
 from ssl import SSLContext
 from types import SimpleNamespace
+from typing import ParamSpec, TypeVar
 
 from aiohttp import ClientSession, TraceConfig, TraceRequestEndParams
 
@@ -44,6 +46,23 @@ async def trace_response(
     )
 
 
+R = TypeVar("R")
+P = ParamSpec("P")
+
+
+def check_mqtt_enabled(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+    """Check if MQTT is enabled before calling the function and otherwise log an error."""
+
+    @functools.wraps(func)
+    async def wrapper(self: MySkoda, *args: P.args, **kwargs: P.kwargs) -> R:
+        if self.enable_mqtt:
+            return await func(self, *args, **kwargs)
+        _LOGGER.error(f"MQTT is disabled, cannot perform {func.__name__}")
+        return None
+
+    return wrapper
+
+
 TRACE_CONFIG = TraceConfig()
 TRACE_CONFIG.on_request_end.append(trace_response)
 
@@ -53,13 +72,19 @@ class MySkoda:
     rest_api: RestApi
     mqtt: Mqtt
     authorization: Authorization
+    enable_mqtt: bool
 
     def __init__(  # noqa: D107
-        self, session: ClientSession, ssl_context: SSLContext | None = None
+        self,
+        session: ClientSession,
+        ssl_context: SSLContext | None = None,
+        *,
+        enable_mqtt: bool = True,
     ) -> None:
         self.session = session
         self.authorization = Authorization(session)
         self.rest_api = RestApi(self.session, self.authorization)
+        self.enable_mqtt = enable_mqtt
         self.mqtt = Mqtt(self.authorization, self.rest_api, ssl_context=ssl_context)
 
     async def connect(self, email: str, password: str) -> None:
@@ -67,83 +92,98 @@ class MySkoda:
         await self.authorization.authorize(email, password)
         _LOGGER.info("IDK Authorization was successful.")
 
-        await self.mqtt.connect()
+        if self.enable_mqtt:
+            await self.mqtt.connect()
         _LOGGER.debug("Myskoda ready.")
 
+    @check_mqtt_enabled
     def subscribe(self, callback: Callable[[Event], None | Awaitable[None]]) -> None:
         """Listen for events emitted by MySkoda's MQTT broker."""
         self.mqtt.subscribe(callback)
 
     def disconnect(self) -> None:
         """Disconnect from the MQTT broker."""
-        self.mqtt.disconnect()
+        if self.enable_mqtt:
+            self.mqtt.disconnect()
 
+    @check_mqtt_enabled
     async def stop_charging(self, vin: str) -> None:
         """Stop the car from charging."""
         future = self.mqtt.wait_for_operation(OperationName.STOP_CHARGING)
         await self.rest_api.stop_charging(vin)
         await future
 
+    @check_mqtt_enabled
     async def start_charging(self, vin: str) -> None:
         """Start charging the car."""
         future = self.mqtt.wait_for_operation(OperationName.START_CHARGING)
         await self.rest_api.start_charging(vin)
         await future
 
+    @check_mqtt_enabled
     async def honk_flash(self, vin: str, honk: bool = False) -> None:  # noqa: FBT002
         """Honk and/or flash."""
         future = self.mqtt.wait_for_operation(OperationName.START_HONK)
         await self.rest_api.honk_flash(vin, honk)
         await future
 
+    @check_mqtt_enabled
     async def wakeup(self, vin: str) -> None:
         """Wake the vehicle up. Can be called maximum three times a day."""
         future = self.mqtt.wait_for_operation(OperationName.WAKEUP)
         await self.rest_api.honk_flash(vin)
         await future
 
+    @check_mqtt_enabled
     async def set_reduced_current_limit(self, vin: str, reduced: bool) -> None:
         """Enable reducing the current limit by which the car is charged."""
         future = self.mqtt.wait_for_operation(OperationName.UPDATE_CHARGING_CURRENT)
         await self.rest_api.set_reduced_current_limit(vin, reduced=reduced)
         await future
 
+    @check_mqtt_enabled
     async def set_battery_care_mode(self, vin: str, enabled: bool) -> None:
         """Enable or disable the battery care mode."""
         future = self.mqtt.wait_for_operation(OperationName.UPDATE_CARE_MODE)
         await self.rest_api.set_battery_care_mode(vin, enabled)
         await future
 
+    @check_mqtt_enabled
     async def set_charge_limit(self, vin: str, limit: int) -> None:
         """Set the maximum charge limit in percent."""
         future = self.mqtt.wait_for_operation(OperationName.UPDATE_CHARGE_LIMIT)
         await self.rest_api.set_charge_limit(vin, limit)
         await future
 
+    @check_mqtt_enabled
     async def stop_window_heating(self, vin: str) -> None:
         """Stop heating both the front and rear window."""
         future = self.mqtt.wait_for_operation(OperationName.STOP_WINDOW_HEATING)
         await self.rest_api.stop_window_heating(vin)
         await future
 
+    @check_mqtt_enabled
     async def start_window_heating(self, vin: str) -> None:
         """Start heating both the front and rear window."""
         future = self.mqtt.wait_for_operation(OperationName.START_WINDOW_HEATING)
         await self.rest_api.start_window_heating(vin)
         await future
 
+    @check_mqtt_enabled
     async def set_target_temperature(self, vin: str, temperature: float) -> None:
         """Set the air conditioning's target temperature in °C."""
         future = self.mqtt.wait_for_operation(OperationName.SET_AIR_CONDITIONING_TARGET_TEMPERATURE)
         await self.rest_api.set_target_temperature(vin, temperature)
         await future
 
+    @check_mqtt_enabled
     async def start_air_conditioning(self, vin: str, temperature: float) -> None:
         """Start the air conditioning with the provided target temperature in °C."""
         future = self.mqtt.wait_for_operation(OperationName.START_AIR_CONDITIONING)
         await self.rest_api.start_air_conditioning(vin, temperature)
         await future
 
+    @check_mqtt_enabled
     async def stop_air_conditioning(self, vin: str) -> None:
         """Stop the air conditioning."""
         future = self.mqtt.wait_for_operation(OperationName.STOP_AIR_CONDITIONING)


### PR DESCRIPTION
An enable_mqtt flag was added to the MySkoda class. The flag is True by default so that MQTT will always be used unless we specify otherwise. 
The necessary checks are in place to set up (or not) the MQTT connection. A decorator that can be set on the methods that need MQTT will help us prevent long troubleshooting when we forget to enable the flag in the future. It would log an error if we disable MQTT but we try to do something with it anyway.

The CLI class was adjusted to do make the connection in the commands itself instead of the cli group. This is so that we can set MQTT disabled by default for CLI. A decorator helps us to easily indicate to enable MQTT. The ensure_connected function will retrieve all necessary information from the context and call the MySkoda connect method (with the correct setting of mqtt).

This PR relates to #26 