### PR TITLE
Remove ruff G004 exception

### DIFF
--- a/myskoda/models/info.py
+++ b/myskoda/models/info.py
@@ -105,7 +105,7 @@ def drop_unknown_capabilities(value: list[dict]) -> list[Capability]:
     """Drop any unknown capabilities and log a message."""
     unknown_capabilities = [c for c in value if c["id"] not in CapabilityId]
     if unknown_capabilities:
-        _LOGGER.info(f"Dropping unknown capabilities: {unknown_capabilities}")
+        _LOGGER.info("Dropping unknown capabilities: %s", unknown_capabilities)
     return [Capability.from_dict(c) for c in value if c["id"] in CapabilityId]
 
 

--- a/myskoda/mqtt.py
+++ b/myskoda/mqtt.py
@@ -102,7 +102,7 @@ class Mqtt:
 
             if not self.user:
                 self.user = await self.api.get_user()
-                _LOGGER.debug(f"Using user id {self.user.id}...")
+                _LOGGER.debug("Using user id %s...", self.user.id)
 
             if not self.vehicles:
                 self.vehicles = await self.api.list_vehicles()

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -37,13 +37,14 @@ async def trace_response(
     params: TraceRequestEndParams,
 ) -> None:
     """Log response details. Used in aiohttp.TraceConfig."""
+    resp_text_5000 = await params.response.text()[:5000]
     _LOGGER.debug(
         "Trace: %s %s - response: %s (%s bytes) %s",
         params.method,
         str(params.url)[:60],
         params.response.status,
         params.response.content_length,
-        await params.response.text()[:5000],
+        resp_text_5000,
     )
 
 

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -38,9 +38,12 @@ async def trace_response(
 ) -> None:
     """Log response details. Used in aiohttp.TraceConfig."""
     _LOGGER.debug(
-        f"Trace: {params.method} {str(params.url)[:60]} - "
-        f"response: {params.response.status} ({params.response.content_length} bytes) "
-        f"{(await params.response.text())[:5000]}"
+        "Trace: %s %s - response: %s (%s bytes) %s",
+        params.method,
+        str(params.url)[:60],
+        params.response.status,
+        params.response.content_length,
+        await params.response.text()[:5000],
     )
 
 

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -37,14 +37,14 @@ async def trace_response(
     params: TraceRequestEndParams,
 ) -> None:
     """Log response details. Used in aiohttp.TraceConfig."""
-    resp_text_5000 = await params.response.text()[:5000]
+    resp_text = await params.response.text()
     _LOGGER.debug(
         "Trace: %s %s - response: %s (%s bytes) %s",
         params.method,
         str(params.url)[:60],
         params.response.status,
         params.response.content_length,
-        resp_text_5000,
+        resp_text[:5000],
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ ignore = [
     "D213",   # multi-line-summary-second-line
     "FBT001", # boolean-type-hint-positional-argument
     "FIX002", # line-contains-todo
-    "G004",   # logging-f-string
     "ISC001", # single-line-implicit-string-concatenation
     "S101",   # assert (used in tests)
     "T201",   # print


### PR DESCRIPTION
Following some remarks this week about f-style and logging:
Remove f-style strings from logging statements and disable G004 exception