### PR TITLE
Make Service Partner optional in Info

### DIFF
--- a/myskoda/models/info.py
+++ b/myskoda/models/info.py
@@ -189,7 +189,9 @@ class Info(DataClassORJSONMixin):
     name: str
     capabilities: Capabilities
     device_platform: str = field(metadata=field_options(alias="devicePlatform"))
-    service_partner: ServicePartner | None = field(default=None, metadata=field_options(alias="servicePartner"))
+    service_partner: ServicePartner | None = field(
+        default=None, metadata=field_options(alias="servicePartner")
+    )
     workshop_mode_enabled: bool = field(metadata=field_options(alias="workshopModeEnabled"))
     software_version: str | None = field(
         default=None, metadata=field_options(alias="softwareVersion")

--- a/myskoda/models/info.py
+++ b/myskoda/models/info.py
@@ -189,7 +189,7 @@ class Info(DataClassORJSONMixin):
     name: str
     capabilities: Capabilities
     device_platform: str = field(metadata=field_options(alias="devicePlatform"))
-    service_partner: ServicePartner = field(metadata=field_options(alias="servicePartner"))
+    service_partner: ServicePartner | None = field(default=None, metadata=field_options(alias="servicePartner"))
     workshop_mode_enabled: bool = field(metadata=field_options(alias="workshopModeEnabled"))
     software_version: str | None = field(
         default=None, metadata=field_options(alias="softwareVersion")

--- a/myskoda/models/info.py
+++ b/myskoda/models/info.py
@@ -189,10 +189,10 @@ class Info(DataClassORJSONMixin):
     name: str
     capabilities: Capabilities
     device_platform: str = field(metadata=field_options(alias="devicePlatform"))
+    workshop_mode_enabled: bool = field(metadata=field_options(alias="workshopModeEnabled"))
     service_partner: ServicePartner | None = field(
         default=None, metadata=field_options(alias="servicePartner")
     )
-    workshop_mode_enabled: bool = field(metadata=field_options(alias="workshopModeEnabled"))
     software_version: str | None = field(
         default=None, metadata=field_options(alias="softwareVersion")
     )


### PR DESCRIPTION
If you haven't chosen a Service Partner yet in the app this field is not sent from the API.

If something isn't correct let me know!

@dvx76 

Edit: fixes #63 and skodaconnect/homeassistant-myskoda#50