### PR TITLE
Error handling for trip-statistics in CLI

### DIFF
--- a/myskoda/cli.py
+++ b/myskoda/cli.py
@@ -15,6 +15,7 @@ import asyncclick as click
 import coloredlogs
 import yaml
 from aiohttp import ClientSession
+from aiohttp.client_exceptions import ClientResponseError
 from asyncclick.core import Context
 from pygments import highlight
 from pygments.formatters import TerminalFormatter
@@ -25,7 +26,6 @@ from myskoda.event import Event
 from myskoda.models.operation_request import OperationName
 
 from .myskoda import TRACE_CONFIG, MqttDisabledError, MySkoda
-from .rest_api import InvalidResponseError
 
 
 def mqtt_required[R](func: Callable[..., Awaitable[R]]) -> Callable[..., Awaitable[Awaitable[R]]]:
@@ -236,8 +236,8 @@ async def trip_statistics(ctx: Context, vin: str) -> None:
     try:
         stats = await myskoda.get_trip_statistics(vin)
         ctx.obj["print"](stats.to_dict())
-    except InvalidResponseError as e:
-        ctx.obj["print"]({"error": e.response})
+    except ClientResponseError as e:
+        ctx.obj["print"]({"error": e.status, "message": e.message, "url": str(e.request_info.url)})
 
 
 @cli.command()

--- a/myskoda/cli.py
+++ b/myskoda/cli.py
@@ -22,6 +22,7 @@ from termcolor import colored
 from .event import Event
 from .models.operation_request import OperationName
 from .myskoda import TRACE_CONFIG, MySkoda
+from .rest_api import InvalidResponseError
 
 
 class Format(StrEnum):
@@ -207,8 +208,11 @@ async def user(ctx: Context) -> None:
 async def trip_statistics(ctx: Context, vin: str) -> None:
     """Print the last trip statics."""
     myskoda: MySkoda = ctx.obj["myskoda"]
-    stats = await myskoda.get_trip_statistics(vin)
-    ctx.obj["print"](stats.to_dict())
+    try:
+        stats = await myskoda.get_trip_statistics(vin)
+        ctx.obj["print"](stats.to_dict())
+    except InvalidResponseError as e:
+        ctx.obj["print"]({"error": e.response})
 
 
 @cli.command()

--- a/myskoda/cli.py
+++ b/myskoda/cli.py
@@ -10,6 +10,7 @@ from collections.abc import Awaitable, Callable
 from enum import StrEnum
 from functools import update_wrapper
 from logging import DEBUG, INFO
+from typing import Any
 
 import asyncclick as click
 import coloredlogs
@@ -40,6 +41,18 @@ def mqtt_required[R](func: Callable[..., Awaitable[R]]) -> Callable[..., Awaitab
         return await ctx.invoke(func, *args, **kwargs)
 
     return update_wrapper(new_func, func)
+
+
+async def handle_request(ctx: Context, func: Callable[..., Awaitable], *args: Any) -> None:  # noqa: ANN401
+    """Handle API requests and perform error handling."""
+    try:
+        result = await func(*args)
+        if hasattr(result, "to_dict"):
+            ctx.obj["print"](result.to_dict())
+        else:
+            ctx.obj["print"](result)
+    except ClientResponseError as e:
+        ctx.obj["print"]({"error": e.status, "message": e.message, "url": str(e.request_info.url)})
 
 
 class Format(StrEnum):
@@ -133,9 +146,7 @@ async def auth(ctx: Context) -> None:
 @click.pass_context
 async def list_vehicles(ctx: Context) -> None:
     """Print a list of all vehicle identification numbers associated with the account."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    vehicles = await myskoda.list_vehicle_vins()
-    ctx.obj["print"](vehicles)
+    await handle_request(ctx, ctx.obj["myskoda"].list_vehicle_vins)
 
 
 @cli.command()
@@ -143,9 +154,7 @@ async def list_vehicles(ctx: Context) -> None:
 @click.pass_context
 async def info(ctx: Context, vin: str) -> None:
     """Print info for the specified vin."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    info = await myskoda.get_info(vin)
-    ctx.obj["print"](info.to_dict())
+    await handle_request(ctx, ctx.obj["myskoda"].get_info, vin)
 
 
 @cli.command()
@@ -153,9 +162,7 @@ async def info(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def status(ctx: Context, vin: str) -> None:
     """Print current status for the specified vin."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    status = await myskoda.get_status(vin)
-    ctx.obj["print"](status.to_dict())
+    await handle_request(ctx, ctx.obj["myskoda"].get_status, vin)
 
 
 @cli.command()
@@ -163,9 +170,7 @@ async def status(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def air_conditioning(ctx: Context, vin: str) -> None:
     """Print current status about air conditioning."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    ac = await myskoda.get_air_conditioning(vin)
-    ctx.obj["print"](ac.to_dict())
+    await handle_request(ctx, ctx.obj["myskoda"].get_air_conditioning, vin)
 
 
 @cli.command()
@@ -173,9 +178,7 @@ async def air_conditioning(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def positions(ctx: Context, vin: str) -> None:
     """Print the vehicle's current position."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    positions = await myskoda.get_positions(vin)
-    ctx.obj["print"](positions.to_dict())
+    await handle_request(ctx, ctx.obj["myskoda"].get_positions, vin)
 
 
 @cli.command()
@@ -183,9 +186,7 @@ async def positions(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def health(ctx: Context, vin: str) -> None:
     """Print the vehicle's mileage."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    health = await myskoda.get_health(vin)
-    ctx.obj["print"](health.to_dict())
+    await handle_request(ctx, ctx.obj["myskoda"].get_health, vin)
 
 
 @cli.command()
@@ -193,9 +194,7 @@ async def health(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def charging(ctx: Context, vin: str) -> None:
     """Print the vehicle's current charging state."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    charging = await myskoda.get_charging(vin)
-    ctx.obj["print"](charging.to_dict())
+    await handle_request(ctx, ctx.obj["myskoda"].get_charging, vin)
 
 
 @cli.command()
@@ -203,9 +202,7 @@ async def charging(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def maintenance(ctx: Context, vin: str) -> None:
     """Print the vehicle's maintenance information."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    maintenance = await myskoda.get_maintenance(vin)
-    ctx.obj["print"](maintenance.to_dict())
+    await handle_request(ctx, ctx.obj["myskoda"].get_maintenance, vin)
 
 
 @cli.command()
@@ -213,18 +210,14 @@ async def maintenance(ctx: Context, vin: str) -> None:
 @click.pass_context
 async def driving_range(ctx: Context, vin: str) -> None:
     """Print the vehicle's estimated driving range information."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    driving_range = await myskoda.get_driving_range(vin)
-    ctx.obj["print"](driving_range.to_dict())
+    await handle_request(ctx, ctx.obj["myskoda"].get_driving_range, vin)
 
 
 @cli.command()
 @click.pass_context
 async def user(ctx: Context) -> None:
     """Print information about currently logged in user."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    user = await myskoda.get_user()
-    ctx.obj["print"](user.to_dict())
+    await handle_request(ctx, ctx.obj["myskoda"].get_user)
 
 
 @cli.command()
@@ -232,12 +225,7 @@ async def user(ctx: Context) -> None:
 @click.pass_context
 async def trip_statistics(ctx: Context, vin: str) -> None:
     """Print the last trip statics."""
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    try:
-        stats = await myskoda.get_trip_statistics(vin)
-        ctx.obj["print"](stats.to_dict())
-    except ClientResponseError as e:
-        ctx.obj["print"]({"error": e.status, "message": e.message, "url": str(e.request_info.url)})
+    await handle_request(ctx, ctx.obj["myskoda"].get_trip_statistics, vin)
 
 
 @cli.command()

--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -4,7 +4,6 @@ import logging
 from collections.abc import Callable
 
 from aiohttp import ClientSession
-from orjson import JSONDecodeError
 
 from .auth.authorization import Authorization
 from .const import BASE_URL_SKODA
@@ -37,11 +36,10 @@ class RestApi:
             f"{BASE_URL_SKODA}/api{url}",
             headers=await self._headers(),
         ) as response:
+            response.raise_for_status()
             response_text = await response.text()
             try:
                 data = deserialize(response_text)
-            except JSONDecodeError as e:
-                raise InvalidResponseError(response_text) from e
             except Exception:
                 _LOGGER.exception(
                     "Failed to load data from url %s. Return value was '%s'", url, response_text
@@ -270,12 +268,3 @@ class RestApi:
             json=json_data,
         ) as response:
             await response.text()
-
-
-class InvalidResponseError(Exception):
-    """Indicates that the response was not a valid JSON."""
-
-    def __init__(self, response: str) -> None:
-        """Initialize the error with the actual response."""
-        super().__init__(f"Failed to decode the response: {response}")
-        self.response = response


### PR DESCRIPTION
I tried to add a minimal solution to better handle the trip-statistics error:
  - Added an exception in the rest_api module. The _make_get_request still throws an exception, so behaviour in the overall library should remain the same
  - The CLI catches the new exception and prints it

This should fix #58 , at least by printing the error result instead of throwing an exception.

It also takes into account @dvx76 's remark  that 

> The integration will use get_vehicle which will only try to get statistics if the TRIP_STATISTICS capability is present.

The CLI also still exposes all methods but does not error in case there are no trip statistics.

The fix is minimal in the sense that I think it would be overkill for the trip-statistics method to first check the capabilities and then - depending on the capability being present - get the trip statistics. But that's also a way we could go.