### PR TITLE
#79 Add 'COOLING' state to AirConditioningState

### DIFF
--- a/myskoda/models/air_conditioning.py
+++ b/myskoda/models/air_conditioning.py
@@ -21,12 +21,13 @@ class TimerMode(StrEnum):
 
 
 class AirConditioningState(StrEnum):
+    COOLING = "COOLING"
     HEATING = "HEATING"
     HEATING_AUXILIARY = "HEATING_AUXILIARY"
     OFF = "OFF"
     ON = "ON"
     VENTILATION = "VENTILATION"
-    COOLING = "COOLING"
+
 
 # Probaly other states than AUTOMATIC are available, to be discovered
 class HeaterSource(StrEnum):

--- a/myskoda/models/air_conditioning.py
+++ b/myskoda/models/air_conditioning.py
@@ -26,7 +26,7 @@ class AirConditioningState(StrEnum):
     OFF = "OFF"
     ON = "ON"
     VENTILATION = "VENTILATION"
-
+    COOLING = "COOLING"
 
 # Probaly other states than AUTOMATIC are available, to be discovered
 class HeaterSource(StrEnum):


### PR DESCRIPTION
This PR adds the missing 'COOLING' state to the AirConditioningState enum in response to issue #79. The issue reported a ValueError due to the missing 'COOLING' state, and I've updated the enum to include this state.

This is my first open source contribution, and I'm excited to be part of the community. Please feel free to provide any feedback or guidance if there's anything I can improve. Thanks.