### PR TITLE
Support case-insensitive StrEnums

### DIFF
--- a/myskoda/models/charging.py
+++ b/myskoda/models/charging.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from .common import ActiveState, EnabledState
+from .common import ActiveState, CaseInsensitiveStrEnum, EnabledState
 
 
 class ChargingErrorType(StrEnum):
@@ -25,7 +25,7 @@ class ChargingError(DataClassORJSONMixin):
     description: str
 
 
-class ChargeMode(StrEnum):
+class ChargeMode(CaseInsensitiveStrEnum):
     HOME_STORAGE_CHARGING = "HOME_STORAGE_CHARGING"
     IMMEDIATE_DISCHARGING = "IMMEDIATE_DISCHARGING"
     ONLY_OWN_CURRENT = "ONLY_OWN_CURRENT"
@@ -41,7 +41,7 @@ class MaxChargeCurrent(StrEnum):
     REDUCED = "REDUCED"
 
 
-class ChargingState(StrEnum):
+class ChargingState(CaseInsensitiveStrEnum):
     READY_FOR_CHARGING = "READY_FOR_CHARGING"
     CONNECT_CABLE = "CONNECT_CABLE"
     CONSERVING = "CONSERVING"

--- a/myskoda/models/common.py
+++ b/myskoda/models/common.py
@@ -7,6 +7,22 @@ from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 
+class CaseInsensitiveStrEnum(StrEnum):
+    @classmethod
+    def _missing_(cls, value: object) -> StrEnum | None:
+        """Ignore the case of the value.
+
+        Some endpoints will return values sometimes as uppercase and sometimes as lowercase...
+        """
+        if not isinstance(value, str):
+            raise TypeError
+        value = value.lower()
+        for member in cls:
+            if member.lower() == value:
+                return member
+        return None
+
+
 class OnOffState(StrEnum):
     ON = "ON"
     OFF = "OFF"


### PR DESCRIPTION
Some endpoints and/or MQTT events return their values as uppercase for some users and lowercase for other users.

Fixes #55