### PR TITLE
Make the REST API wait for the result

### DIFF
--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -44,6 +44,7 @@ class RestApi:
                     headers=await self._headers(),
                     json=json,
                 ) as response:
+                    await response.text()  # Ensure response is fully read
                     response.raise_for_status()
                     return response
         except TimeoutError:
@@ -67,14 +68,10 @@ class RestApi:
             return data
 
     async def _make_post_request(self, url: str, json: dict | None = None) -> ClientResponse:
-        response = await self._make_request(url=url, method="POST", json=json)
-        await response.text()
-        return response
+        return await self._make_request(url=url, method="POST", json=json)
 
     async def _make_put_request(self, url: str, json: dict | None = None) -> ClientResponse:
-        response = await self._make_request(url=url, method="PUT", json=json)
-        await response.text()
-        return response
+        return await self._make_request(url=url, method="PUT", json=json)
 
     async def get_info(self, vin: str) -> Info:
         """Retrieve the basic vehicle information for the specified vehicle."""


### PR DESCRIPTION
Make the REST API wait for the result before returning the client response.

The _make_request now waits until the text() is there before returning the ClientResponse object. This prevents the connection being closed too early.

Making the _make_request method await on the text() also removes the need for post and put methods to do this.

This solves #90 