### PR TITLE
Fix response.text() called outside of request context manager

### DIFF
--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -45,6 +45,7 @@ class RestApi:
                     json=json,
                 ) as response:
                     response.raise_for_status()
+                    await response.text()
                     return response
         except TimeoutError:
             _LOGGER.exception("Timeout while sending %s request to %s", method, url)
@@ -67,14 +68,10 @@ class RestApi:
             return data
 
     async def _make_post_request(self, url: str, json: dict | None = None) -> ClientResponse:
-        response = await self._make_request(url=url, method="POST", json=json)
-        await response.text()
-        return response
+        return await self._make_request(url=url, method="POST", json=json)
 
     async def _make_put_request(self, url: str, json: dict | None = None) -> ClientResponse:
-        response = await self._make_request(url=url, method="PUT", json=json)
-        await response.text()
-        return response
+        return await self._make_request(url=url, method="PUT", json=json)
 
     async def get_info(self, vin: str) -> Info:
         """Retrieve the basic vehicle information for the specified vehicle."""


### PR DESCRIPTION
Introduced in #71