### PR TITLE
WindowsSelectorEventLoopPolicy to global scope

### DIFF
--- a/myskoda/cli/__init__.py
+++ b/myskoda/cli/__init__.py
@@ -43,6 +43,18 @@ from myskoda.cli.requests import (
 )
 from myskoda.cli.utils import Format, print_json, print_yaml
 
+if sys_platform.lower().startswith("win") and sys_version_info >= (3, 8):
+    # Check if we're on windows, if so, tune asyncio to work there as well (https://github.com/skodaconnect/myskoda/issues/77)
+    import asyncio
+
+    try:
+        from asyncio import WindowsSelectorEventLoopPolicy  # type: ignore[unknown-import]
+    except ImportError:
+        pass  # Can't assign a policy which doesn't exist.
+    else:
+        if not isinstance(asyncio.get_event_loop_policy(), WindowsSelectorEventLoopPolicy):
+            asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
+
 
 @click.group()
 @click.version_option()
@@ -83,18 +95,6 @@ async def cli(  # noqa: PLR0913
     trace_configs = []
     if trace:
         trace_configs.append(TRACE_CONFIG)
-
-    # Check if we're on windows, if so, tune asyncio to work there as well (https://github.com/skodaconnect/myskoda/issues/77)
-    if sys_platform.lower().startswith("win") and sys_version_info >= (3, 8):
-        import asyncio
-
-        try:
-            from asyncio import WindowsSelectorEventLoopPolicy  # type: ignore[unknown-import]
-        except ImportError:
-            pass  # Can't assign a policy which doesn't exist.
-        else:
-            if not isinstance(asyncio.get_event_loop_policy(), WindowsSelectorEventLoopPolicy):
-                asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
     session = ClientSession(trace_configs=trace_configs)
     myskoda = MySkoda(session, mqtt_enabled=False)


### PR DESCRIPTION
Move event loop policy check to global scope to initalize at very startup.

It seems that the event loop policy was set too late, or at least for me. Moving it to the global scope did the trick.

Fixes #116 