### PR TITLE
Anonymize VIN in errors saved in fixtures

### DIFF
--- a/myskoda/anonymize.py
+++ b/myskoda/anonymize.py
@@ -1,8 +1,11 @@
 """Methods for anonymizing data from the API."""
 
+import re
+
 ACCESS_TOKEN = "eyJ0eXAiOiI0ODEyODgzZi05Y2FiLTQwMWMtYTI5OC0wZmEyMTA5Y2ViY2EiLCJhbGciOiJSUzI1NiJ9"  # noqa: S105
 USER_ID = "b8bc126c-ee36-402b-8723-2c1c3dff8dec"
 VIN = "TMOCKAA0AA000000"
+VIN_REGEX = re.compile(r"TMB\w{14}")
 ADDRESS = {
     "city": "Example City",
     "street": "Example Avenue",
@@ -112,5 +115,5 @@ def anonymize_garage(data: dict) -> dict:
     return data
 
 
-def anonymize_url(url: str, vin: str) -> str:
-    return url.replace(vin, VIN)
+def anonymize_url(url: str) -> str:
+    return VIN_REGEX.sub(VIN, url)

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from aiohttp import ClientSession, TraceConfig, TraceRequestEndParams
 
+from myskoda.anonymize import anonymize_url
 from myskoda.models.fixtures import (
     Endpoint,
     Fixture,
@@ -307,7 +308,7 @@ class MySkoda:
                 vehicle_id=vehicle.id,
                 success=False,
                 endpoint=endpoint,
-                error=format_exc(),
+                error=anonymize_url(format_exc()),
             )
         else:
             return FixtureReportGet(

--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -109,7 +109,7 @@ class RestApi:
             anonymization_fn=anonymize_info,
         )
         result = self._deserialize(raw, Info.from_json)
-        url = anonymize_url(url, vin) if anonymize else url
+        url = anonymize_url(url) if anonymize else url
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_charging(self, vin: str, anonymize: bool = False) -> GetEndpointResult[Charging]:
@@ -121,7 +121,7 @@ class RestApi:
             anonymization_fn=anonymize_charging,
         )
         result = self._deserialize(raw, Charging.from_json)
-        url = anonymize_url(url, vin) if anonymize else url
+        url = anonymize_url(url) if anonymize else url
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_status(self, vin: str, anonymize: bool = False) -> GetEndpointResult[Status]:
@@ -133,7 +133,7 @@ class RestApi:
             anonymization_fn=anonymize_status,
         )
         result = self._deserialize(raw, Status.from_json)
-        url = anonymize_url(url, vin) if anonymize else url
+        url = anonymize_url(url) if anonymize else url
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_air_conditioning(
@@ -147,7 +147,7 @@ class RestApi:
             anonymization_fn=anonymize_air_conditioning,
         )
         result = self._deserialize(raw, AirConditioning.from_json)
-        url = anonymize_url(url, vin) if anonymize else url
+        url = anonymize_url(url) if anonymize else url
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_positions(
@@ -161,7 +161,7 @@ class RestApi:
             anonymization_fn=anonymize_positions,
         )
         result = self._deserialize(raw, Positions.from_json)
-        url = anonymize_url(url, vin) if anonymize else url
+        url = anonymize_url(url) if anonymize else url
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_driving_range(
@@ -175,7 +175,7 @@ class RestApi:
             anonymization_fn=anonymize_driving_range,
         )
         result = self._deserialize(raw, DrivingRange.from_json)
-        url = anonymize_url(url, vin) if anonymize else url
+        url = anonymize_url(url) if anonymize else url
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_trip_statistics(
@@ -189,7 +189,7 @@ class RestApi:
             anonymization_fn=anonymize_trip_statistics,
         )
         result = self._deserialize(raw, TripStatistics.from_json)
-        url = anonymize_url(url, vin) if anonymize else url
+        url = anonymize_url(url) if anonymize else url
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_maintenance(
@@ -203,7 +203,7 @@ class RestApi:
             anonymization_fn=anonymize_maintenance,
         )
         result = self._deserialize(raw, Maintenance.from_json)
-        url = anonymize_url(url, vin) if anonymize else url
+        url = anonymize_url(url) if anonymize else url
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_health(self, vin: str, anonymize: bool = False) -> GetEndpointResult[Health]:
@@ -215,7 +215,7 @@ class RestApi:
             anonymization_fn=anonymize_health,
         )
         result = self._deserialize(raw, Health.from_json)
-        url = anonymize_url(url, vin) if anonymize else url
+        url = anonymize_url(url) if anonymize else url
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_user(self, anonymize: bool = False) -> GetEndpointResult[User]:


### PR DESCRIPTION
Use regex to find VINs, based on VINs being 17 characters and the Skoda WMI being `TMB`.

Ref: https://www.skoda-storyboard.com/en/skoda-world/what-can-vin-codes-tell-you/

Fixes #100

In retrospect the original VIN is available where the additional call to `anonymize_url` is used so I could have kept the basic string `.replace`. But using regex allows this to be used from anywhere if we need to.

Also maybe I should rename `anonymize_url` to `anonymize_vin`?