### PR TITLE
Temporary workaround for MQTT ConcurrentSubscribeError and stability

### DIFF
--- a/myskoda/mqtt.py
+++ b/myskoda/mqtt.py
@@ -200,7 +200,6 @@ class Mqtt:
         self.is_connected = False
         if self._disconnect_listener is not None:
             self._disconnect_listener.set_result(None)
-        self.reconnect()
 
     def _on_connect_fail(self, client: AsyncioPahoClient, _data: None) -> None:
         if client is not self.client:


### PR DESCRIPTION
Not fully clear about this yet but should at least help avoid skodaconnect/homeassistant-myskoda#140 and #123

When _something_ causes the MQTT connection to drop both the `on_disconnect` and the `on_socket_close` fire and both trigger a reconnect. This leads to a `ConcurrentSubscribeError` and all kinds of weird networking and stability issues throughout HA as a result.