### PR TITLE
Enable mqtt logging

### DIFF
--- a/myskoda/mqtt.py
+++ b/myskoda/mqtt.py
@@ -111,6 +111,7 @@ class Mqtt:
             self.should_reconnect = True
 
             self.client = AsyncioPahoClient()
+            self.client.enable_logger()
             self.client.on_connect = self._on_connect
             self.client.on_message = self._on_message
             self.client.on_subscribe = self._on_subscribe


### PR DESCRIPTION
Might help debugging some of the MQTT issues we're seeing.

Note: ha-core mqtt integration does the same thing.

Example (with `--verbose` / log-level DEBUG):

```
2024-10-28 09:54:33 WALLY myskoda.mqtt[4123] DEBUG Subscribing to topic: uuid/TMBXXXX/account-event/account-event/privacy
2024-10-28 09:54:33 WALLY paho.mqtt.client[4123] DEBUG Sending SUBSCRIBE (d0, m26) [(b'uuid/TMBXXXX/account-event/account-event/privacy', 0)]
2024-10-28 09:54:33 WALLY paho.mqtt.client[4123] DEBUG Received SUBACK
2024-10-28 09:54:47 WALLY paho.mqtt.client[4123] DEBUG Sending PINGREQ
2024-10-28 09:54:47 WALLY paho.mqtt.client[4123] DEBUG Received PINGRESP
```