### PR TITLE
Add start/stop auxiliary-heating and verify_spin support

### DIFF
--- a/myskoda/cli/__init__.py
+++ b/myskoda/cli/__init__.py
@@ -21,8 +21,10 @@ from myskoda.cli.operations import (
     set_reduced_current_limit,
     set_target_temperature,
     start_air_conditioning,
+    start_auxiliary_heating,
     start_window_heating,
     stop_air_conditioning,
+    stop_auxiliary_heating,
     stop_window_heating,
     wakeup,
     lock,
@@ -43,6 +45,7 @@ from myskoda.cli.requests import (
     status,
     trip_statistics,
     user,
+    verify_spin
 )
 from myskoda.cli.utils import Format, print_json, print_yaml
 
@@ -141,6 +144,8 @@ cli.add_command(garage)
 cli.add_command(auth)
 cli.add_command(start_air_conditioning)
 cli.add_command(stop_air_conditioning)
+cli.add_command(start_auxiliary_heating)
+cli.add_command(stop_auxiliary_heating)
 cli.add_command(set_target_temperature)
 cli.add_command(start_window_heating)
 cli.add_command(stop_window_heating)
@@ -153,6 +158,7 @@ cli.add_command(gen_fixtures)
 cli.add_command(lock)
 cli.add_command(unlock)
 cli.add_command(honk_flash)
+cli.add_command(verify_spin)
 
 if __name__ == "__main__":
     cli()

--- a/myskoda/cli/__init__.py
+++ b/myskoda/cli/__init__.py
@@ -29,7 +29,7 @@ from myskoda.cli.operations import (
     wakeup,
     lock,
     unlock,
-    honk_flash
+    honk_flash,
 )
 from myskoda.cli.requests import (
     air_conditioning,
@@ -45,7 +45,7 @@ from myskoda.cli.requests import (
     status,
     trip_statistics,
     user,
-    verify_spin
+    verify_spin,
 )
 from myskoda.cli.utils import Format, print_json, print_yaml
 

--- a/myskoda/cli/operations.py
+++ b/myskoda/cli/operations.py
@@ -47,7 +47,6 @@ async def stop_air_conditioning(ctx: Context, timeout: float, vin: str) -> None:
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
 @click.pass_context
-#@mqtt_required NOTE: 08/11/2024 - no response is published in MQTT (maybe bug in MySkoda api?) so we don't need MQTT
 async def start_auxiliary_heating(
     ctx: Context,
     temperature: float,

--- a/myskoda/cli/operations.py
+++ b/myskoda/cli/operations.py
@@ -34,6 +34,7 @@ async def start_air_conditioning(
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
 @click.pass_context
+@mqtt_required
 async def stop_air_conditioning(ctx: Context, timeout: float, vin: str) -> None:  # noqa: ASYNC109
     """Stop the air conditioning."""
     myskoda: MySkoda = ctx.obj["myskoda"]
@@ -47,6 +48,7 @@ async def stop_air_conditioning(ctx: Context, timeout: float, vin: str) -> None:
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
 @click.pass_context
+@mqtt_required
 async def start_auxiliary_heating(
     ctx: Context,
     temperature: float,
@@ -63,6 +65,7 @@ async def start_auxiliary_heating(
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
 @click.pass_context
+@mqtt_required
 async def stop_auxiliary_heating(ctx: Context, timeout: float, vin: str) -> None:  # noqa: ASYNC109
     """Stop the auxiliary heating."""
     myskoda: MySkoda = ctx.obj["myskoda"]

--- a/myskoda/cli/operations.py
+++ b/myskoda/cli/operations.py
@@ -42,6 +42,35 @@ async def stop_air_conditioning(ctx: Context, timeout: float, vin: str) -> None:
 
 
 @click.command()
+@click.option("temperature", "--temperature", type=float, required=True)
+@click.option("spin", "--spin", type=str, required=True)
+@click.option("timeout", "--timeout", type=float, default=300)
+@click.argument("vin")
+@click.pass_context
+#@mqtt_required NOTE: 08/11/2024 - no response is published in MQTT (maybe bug in MySkoda api?) so we don't need MQTT
+async def start_auxiliary_heating(
+    ctx: Context,
+    temperature: float,
+    spin: str,
+    timeout: float,  # noqa: ASYNC109
+    vin: str,
+) -> None:
+    """Start the auxiliary heating with the provided target temperature in °C."""
+    myskoda: MySkoda = ctx.obj["myskoda"]
+    async with asyncio.timeout(timeout):
+        await myskoda.start_auxiliary_heating(vin, temperature, spin)
+
+@click.command()
+@click.option("timeout", "--timeout", type=float, default=300)
+@click.argument("vin")
+@click.pass_context
+async def stop_auxiliary_heating(ctx: Context, timeout: float, vin: str) -> None:  # noqa: ASYNC109
+    """Stop the auxiliary heating."""
+    myskoda: MySkoda = ctx.obj["myskoda"]
+    async with asyncio.timeout(timeout):
+        await myskoda.stop_auxiliary_heating(vin)
+
+@click.command()
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
 @click.option("temperature", "--temperature", type=float, required=True)
@@ -178,3 +207,4 @@ async def honk_flash(ctx: Context, timeout: float, vin: str, honk: bool) -> None
     myskoda: MySkoda = ctx.obj["myskoda"]
     async with asyncio.timeout(timeout):
         await myskoda.honk_flash(vin, honk)
+

--- a/myskoda/cli/requests.py
+++ b/myskoda/cli/requests.py
@@ -116,6 +116,15 @@ async def garage(ctx: Context, anonymize: bool) -> None:
 
 
 @click.command()
+@click.option("spin", "--spin", type=str, required=True)
+@click.option("anonymize", "--anonymize", help="Strip all personal data.", is_flag=True)
+@click.pass_context
+async def verify_spin(ctx: Context, spin: str, anonymize: bool) -> None:
+    """Verify S-PIN"""
+    await handle_request(ctx, ctx.obj["myskoda"].verify_spin, spin, anonymize)
+
+
+@click.command()
 @click.pass_context
 async def auth(ctx: Context) -> None:
     """Extract the auth token."""

--- a/myskoda/cli/requests.py
+++ b/myskoda/cli/requests.py
@@ -120,7 +120,7 @@ async def garage(ctx: Context, anonymize: bool) -> None:
 @click.option("anonymize", "--anonymize", help="Strip all personal data.", is_flag=True)
 @click.pass_context
 async def verify_spin(ctx: Context, spin: str, anonymize: bool) -> None:
-    """Verify S-PIN"""
+    """Verify S-PIN."""
     await handle_request(ctx, ctx.obj["myskoda"].verify_spin, spin, anonymize)
 
 

--- a/myskoda/const.py
+++ b/myskoda/const.py
@@ -17,7 +17,7 @@ MQTT_OPERATION_TOPICS = [
     "air-conditioning/set-air-conditioning-without-external-power",
     "air-conditioning/set-target-temperature",
     "air-conditioning/start-stop-air-conditioning",
-    "air-conditioning/start-stop-auxiliary-heating",
+    "auxiliary-heating/start-stop-auxiliary-heating",
     "air-conditioning/start-stop-window-heating",
     "air-conditioning/windows-heating",
     "charging/start-stop-charging",
@@ -37,6 +37,7 @@ MQTT_OPERATION_TOPICS = [
 MQTT_SERVICE_EVENT_TOPICS = [
     "air-conditioning",
     "charging",
+    "departure"
     "vehicle-status/access",
     "vehicle-status/lights",
 ]

--- a/myskoda/const.py
+++ b/myskoda/const.py
@@ -37,7 +37,7 @@ MQTT_OPERATION_TOPICS = [
 MQTT_SERVICE_EVENT_TOPICS = [
     "air-conditioning",
     "charging",
-    "departure"
+    "departure",
     "vehicle-status/access",
     "vehicle-status/lights",
 ]

--- a/myskoda/models/spin.py
+++ b/myskoda/models/spin.py
@@ -1,25 +1,28 @@
-"""Models for responses of api/v2/garage/vehicles/{vin}."""
+"""Models for responses of api/v1/spin/verify."""
 
-import logging
 from dataclasses import dataclass, field
 from enum import StrEnum
 
+from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-_LOGGER = logging.getLogger(__name__)
 
 class VerificationStatus(StrEnum):
     """List of known statuses for SPIN."""
+
     CORRECT_SPIN = "CORRECT_SPIN"
     INCORRECT_SPIN = "INCORRECT_SPIN"
 
 @dataclass
 class SpinStatus(DataClassORJSONMixin):
     state: str
-    remainingTries: int
-    lockedWaitingTimeInSeconds: int
+    remaining_tries: int = field(metadata=field_options(alias="remainingTries"))
+    locked_waiting_time_in_seconds: int = field(
+        metadata=field_options(alias="lockedWaitingTimeInSeconds"))
 
 @dataclass
 class Spin(DataClassORJSONMixin):
-    verificationStatus: VerificationStatus
-    spinStatus: SpinStatus | None = field(default=None)
+    verification_status: VerificationStatus = field(
+        metadata=field_options(alias="verificationStatus"))
+    spin_status: SpinStatus | None = field(default=None,
+        metadata=field_options(alias="spinStatus"))

--- a/myskoda/models/spin.py
+++ b/myskoda/models/spin.py
@@ -1,0 +1,25 @@
+"""Models for responses of api/v2/garage/vehicles/{vin}."""
+
+import logging
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+_LOGGER = logging.getLogger(__name__)
+
+class VerificationStatus(StrEnum):
+    """List of known statuses for SPIN."""
+    CORRECT_SPIN = "CORRECT_SPIN"
+    INCORRECT_SPIN = "INCORRECT_SPIN"
+
+@dataclass
+class SpinStatus(DataClassORJSONMixin):
+    state: str
+    remainingTries: int
+    lockedWaitingTimeInSeconds: int
+
+@dataclass
+class Spin(DataClassORJSONMixin):
+    verificationStatus: VerificationStatus
+    spinStatus: SpinStatus | None = field(default=None)

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -37,6 +37,7 @@ from .models.position import Positions
 from .models.status import Status
 from .models.trip_statistics import TripStatistics
 from .models.user import User
+from .models.spin import Spin
 from .mqtt import MySkodaMqttClient
 from .rest_api import GetEndpointResult, RestApi
 from .vehicle import Vehicle
@@ -217,6 +218,20 @@ class MySkoda:
         await self.rest_api.stop_air_conditioning(vin)
         await future
 
+    async def start_auxiliary_heating(self, vin: str, temperature: float, spin: str = "") -> None:
+        """Start the auxiliary heating with the provided target temperature in °C."""
+        # NOTE: 08/11/2024 - no response is published in MQTT (maybe bug in MySkoda api?) so we don't wait
+        # future = self._wait_for_operation(OperationName.START_AUXILIARY_HEATING)
+        await self.rest_api.start_auxiliary_heating(vin, temperature, spin)
+        # await future
+
+    async def stop_auxiliary_heating(self, vin: str) -> None:
+        """Stop the auxiliary heating."""
+        # NOTE: 08/11/2024 - no response is published in MQTT (maybe bug in MySkoda api?) so we don't wait
+        # future = self._wait_for_operation(OperationName.STOP_AUXILIARY_HEATING)
+        await self.rest_api.stop_auxiliary_heating(vin)
+        # await future
+
     async def lock(self, vin: str, spin: str) -> None:
         """Lock the car."""
         future = self._wait_for_operation(OperationName.LOCK)
@@ -232,6 +247,10 @@ class MySkoda:
     async def get_auth_token(self) -> str:
         """Retrieve the main access token for the IDK session."""
         return await self.rest_api.authorization.get_access_token()
+
+    async def verify_spin(self, spin: str, anonymize: bool = False) -> Spin:
+        """Verify S-PIN."""
+        return (await self.rest_api.verify_spin(spin, anonymize=anonymize)).result
 
     async def get_info(self, vin: str, anonymize: bool = False) -> Info:
         """Retrieve the basic vehicle information for the specified vehicle."""

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -218,16 +218,16 @@ class MySkoda:
         await self.rest_api.stop_air_conditioning(vin)
         await future
 
-    async def start_auxiliary_heating(self, vin: str, temperature: float, spin: str = "") -> None:
+    async def start_auxiliary_heating(self, vin: str, temperature: float, spin: str) -> None:
         """Start the auxiliary heating with the provided target temperature in °C."""
-        # NOTE: 08/11/2024 - no response is published in MQTT (maybe bug in MySkoda api?) so we don't wait
+        # NOTE: 08/11/2024 - no response is published in MQTT (maybe bug in api?) so we don't wait
         # future = self._wait_for_operation(OperationName.START_AUXILIARY_HEATING)
         await self.rest_api.start_auxiliary_heating(vin, temperature, spin)
         # await future
 
     async def stop_auxiliary_heating(self, vin: str) -> None:
         """Stop the auxiliary heating."""
-        # NOTE: 08/11/2024 - no response is published in MQTT (maybe bug in MySkoda api?) so we don't wait
+        # NOTE: 08/11/2024 - no response is published in MQTT (maybe bug in api?) so we don't wait
         # future = self._wait_for_operation(OperationName.STOP_AUXILIARY_HEATING)
         await self.rest_api.stop_auxiliary_heating(vin)
         # await future

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -221,16 +221,16 @@ class MySkoda:
     async def start_auxiliary_heating(self, vin: str, temperature: float, spin: str) -> None:
         """Start the auxiliary heating with the provided target temperature in °C."""
         # NOTE: 08/11/2024 - no response is published in MQTT (maybe bug in api?) so we don't wait
-        # future = self._wait_for_operation(OperationName.START_AUXILIARY_HEATING)
+        future = self._wait_for_operation(OperationName.START_AUXILIARY_HEATING)
         await self.rest_api.start_auxiliary_heating(vin, temperature, spin)
-        # await future
+        await future
 
     async def stop_auxiliary_heating(self, vin: str) -> None:
         """Stop the auxiliary heating."""
         # NOTE: 08/11/2024 - no response is published in MQTT (maybe bug in api?) so we don't wait
-        # future = self._wait_for_operation(OperationName.STOP_AUXILIARY_HEATING)
+        future = self._wait_for_operation(OperationName.STOP_AUXILIARY_HEATING)
         await self.rest_api.stop_auxiliary_heating(vin)
-        # await future
+        await future
 
     async def lock(self, vin: str, spin: str) -> None:
         """Lock the car."""

--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -103,7 +103,7 @@ class RestApi:
 
     async def verify_spin(self, spin: str, anonymize: bool = False) -> GetEndpointResult[Spin]:
         """Verify SPIN."""
-        url = f"/v1/spin/verify"
+        url = "/v1/spin/verify"
         json_data = {"currentSpin": spin}
         raw = self.process_json(
             data=await self._make_post_request(url, json_data),
@@ -264,15 +264,16 @@ class RestApi:
 
     async def start_air_conditioning(self, vin: str, temperature: float) -> None:
         """Start the air conditioning."""
+        round_temp = f"{round(temperature * 2) / 2:.1f}"
         _LOGGER.debug(
             "Starting air conditioning for vehicle %s with temperature %s",
             vin,
-            str(temperature),
+            round_temp,
         )
         json_data = {
             "heaterSource": "ELECTRIC",
             "targetTemperature": {
-                "temperatureValue": str(temperature),
+                "temperatureValue": round_temp,
                 "unitInCar": "CELSIUS",
             },
         }
@@ -286,19 +287,20 @@ class RestApi:
         _LOGGER.debug("Stopping auxiliary heating for vehicle %s", vin)
         await self._make_post_request(url=f"/v2/air-conditioning/{vin}/auxiliary-heating/stop")
 
-    async def start_auxiliary_heating(self, vin: str, temperature: float, spin: str = "") -> None:
+    async def start_auxiliary_heating(self, vin: str, temperature: float, spin: str) -> None:
         """Start the auxiliary heating."""
+        round_temp = f"{round(temperature * 2) / 2:.1f}"
         _LOGGER.debug(
             "Starting auxiliary heating for vehicle %s with temperature %s",
             vin,
-            str(temperature),
+            round_temp,
         )
         json_data = {
             "heaterSource": "AUTOMATIC",
             "airConditioningWithoutExternalPower": True,
             "spin": spin,
             "targetTemperature": {
-                "temperatureValue": str(temperature),
+                "temperatureValue": round_temp,
                 "unitInCar": "CELSIUS",
             },
         }
@@ -309,8 +311,9 @@ class RestApi:
 
     async def set_target_temperature(self, vin: str, temperature: float) -> None:
         """Set the air conditioning's target temperature in °C."""
-        _LOGGER.debug("Setting target temperature for vehicle %s to %s", vin, str(temperature))
-        json_data = {"temperatureValue": str(temperature), "unitInCar": "CELSIUS"}
+        round_temp = f"{round(temperature * 2) / 2:.1f}"
+        _LOGGER.debug("Setting target temperature for vehicle %s to %s", vin, round_temp)
+        json_data = {"temperatureValue": round_temp, "unitInCar": "CELSIUS"}
         await self._make_post_request(
             url=f"/v2/air-conditioning/{vin}/settings/target-temperature",
             json=json_data,

--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -38,6 +38,7 @@ from .models.position import Positions
 from .models.status import Status
 from .models.trip_statistics import TripStatistics
 from .models.user import User
+from .models.spin import Spin
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -99,6 +100,19 @@ class RestApi:
 
     async def _make_put_request(self, url: str, json: dict | None = None) -> str:
         return await self._make_request(url=url, method="PUT", json=json)
+
+    async def verify_spin(self, spin: str, anonymize: bool = False) -> GetEndpointResult[Spin]:
+        """Verify SPIN."""
+        url = f"/v1/spin/verify"
+        json_data = {"currentSpin": spin}
+        raw = self.process_json(
+            data=await self._make_post_request(url, json_data),
+            anonymize=anonymize,
+            anonymization_fn=anonymize_info,
+        )
+        result = self._deserialize(raw, Spin.from_json)
+        url = anonymize_url(url) if anonymize else url
+        return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_info(self, vin: str, anonymize: bool = False) -> GetEndpointResult[Info]:
         """Retrieve information related to basic information for the specified vehicle."""
@@ -264,6 +278,32 @@ class RestApi:
         }
         await self._make_post_request(
             url=f"/v2/air-conditioning/{vin}/start",
+            json=json_data,
+        )
+
+    async def stop_auxiliary_heating(self, vin: str) -> None:
+        """Stop the auxiliary heating."""
+        _LOGGER.debug("Stopping auxiliary heating for vehicle %s", vin)
+        await self._make_post_request(url=f"/v2/air-conditioning/{vin}/auxiliary-heating/stop")
+
+    async def start_auxiliary_heating(self, vin: str, temperature: float, spin: str = "") -> None:
+        """Start the auxiliary heating."""
+        _LOGGER.debug(
+            "Starting auxiliary heating for vehicle %s with temperature %s",
+            vin,
+            str(temperature),
+        )
+        json_data = {
+            "heaterSource": "AUTOMATIC",
+            "airConditioningWithoutExternalPower": True,
+            "spin": spin,
+            "targetTemperature": {
+                "temperatureValue": str(temperature),
+                "unitInCar": "CELSIUS",
+            },
+        }
+        await self._make_post_request(
+            url=f"/v2/air-conditioning/{vin}/auxiliary-heating/start",
             json=json_data,
         )
 

--- a/tests/fixtures/superb/verify-spin-correct.json
+++ b/tests/fixtures/superb/verify-spin-correct.json
@@ -1,0 +1,3 @@
+{
+    "verificationStatus": "CORRECT_SPIN"
+}

--- a/tests/fixtures/superb/verify-spin-incorrect.json
+++ b/tests/fixtures/superb/verify-spin-incorrect.json
@@ -1,0 +1,8 @@
+{
+    "verificationStatus": "INCORRECT_SPIN",
+    "spinStatus": {
+        "remainingTries": 2,
+        "lockedWaitingTimeInSeconds": 0,
+        "state": "DEFINED"
+    }
+}

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -33,9 +33,14 @@ async def test_stop_air_conditioning(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("temperature", [21.5, 23.5, 10])
+@pytest.mark.parametrize(("temperature", "expected"),
+                         [(21.5, "21.5"), (23.2, "23.0"), (10.01, "10.0")])
 async def test_start_air_conditioning(
-    responses: aioresponses, mqtt_client: MQTTClient, myskoda: MySkoda, temperature: float
+        responses: aioresponses,
+        mqtt_client: MQTTClient,
+        myskoda: MySkoda,
+        temperature: float,
+        expected: str
 ) -> None:
     url = f"{BASE_URL_SKODA}/api/v2/air-conditioning/{VIN}/start"
     responses.post(url=url)
@@ -52,15 +57,20 @@ async def test_start_air_conditioning(
         headers={"authorization": f"Bearer {ACCESS_TOKEN}"},
         json={
             "heaterSource": "ELECTRIC",
-            "targetTemperature": {"temperatureValue": f"{temperature}", "unitInCar": "CELSIUS"},
+            "targetTemperature": {"temperatureValue": f"{expected}", "unitInCar": "CELSIUS"},
         },
     )
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("temperature", [21.5, 23.5, 10])
+@pytest.mark.parametrize(("temperature", "expected"),
+                         [(21.5, "21.5"), (23.2, "23.0"), (10.01, "10.0")])
 async def test_set_target_temperature(
-    responses: aioresponses, mqtt_client: MQTTClient, myskoda: MySkoda, temperature: float
+        responses: aioresponses,
+        mqtt_client: MQTTClient,
+        myskoda: MySkoda,
+        temperature: float,
+        expected: str
 ) -> None:
     url = f"{BASE_URL_SKODA}/api/v2/air-conditioning/{VIN}/settings/target-temperature"
     responses.post(url=url)
@@ -77,7 +87,7 @@ async def test_set_target_temperature(
         url=url,
         method="POST",
         headers={"authorization": f"Bearer {ACCESS_TOKEN}"},
-        json={"temperatureValue": f"{temperature}", "unitInCar": "CELSIUS"},
+        json={"temperatureValue": f"{expected}", "unitInCar": "CELSIUS"},
     )
 
 
@@ -374,9 +384,15 @@ async def test_stop_auxiliary_heater(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(("temperature", "spin"), [(21.5,"1234"), (23.5,"1234"), (10,"1234")])
+@pytest.mark.parametrize(("temperature", "expected", "spin"),
+                         [(21.5, "21.5", "1234"), (23.2, "23.0", "1234"), (10.01, "10.0", "1234")])
 async def test_start_auxiliary_heater(
-    responses: aioresponses, mqtt_client: MQTTClient, myskoda: MySkoda, temperature: float, spin: str
+        responses: aioresponses,
+        mqtt_client: MQTTClient,
+        myskoda: MySkoda,
+        temperature: float,
+        expected: str,
+        spin: str
 ) -> None:
     url = f"{BASE_URL_SKODA}/api/v2/air-conditioning/{VIN}/auxiliary-heating/start"
     responses.post(url=url)
@@ -395,6 +411,6 @@ async def test_start_auxiliary_heater(
             "heaterSource": "AUTOMATIC",
             "airConditioningWithoutExternalPower": True,
             "spin": spin,
-            "targetTemperature": {"temperatureValue": f"{temperature}", "unitInCar": "CELSIUS"},
+            "targetTemperature": {"temperatureValue": f"{expected}", "unitInCar": "CELSIUS"},
         },
     )

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -371,7 +371,7 @@ async def test_stop_auxiliary_heater(
 
     future = myskoda.stop_auxiliary_heating(VIN)
 
-    topic = f"{USER_ID}/{VIN}/operation-request/air-conditioning/start-stop-auxiliary-heating"
+    topic = f"{USER_ID}/{VIN}/operation-request/auxiliary-heating/start-stop-auxiliary-heating"
     await mqtt_client.publish(topic, create_completed_json("stop-auxiliary-heating"), QOS_2)
 
     await future
@@ -399,7 +399,7 @@ async def test_start_auxiliary_heater(
 
     future = myskoda.start_auxiliary_heating(VIN, temperature, spin)
 
-    topic = f"{USER_ID}/{VIN}/operation-request/air-conditioning/start-stop-auxiliary-heating"
+    topic = f"{USER_ID}/{VIN}/operation-request/auxiliary-heating/start-stop-auxiliary-heating"
     await mqtt_client.publish(topic, create_completed_json("start-auxiliary-heating"), QOS_2)
 
     await future

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -236,13 +236,16 @@ async def test_get_spin_status(
         spin_status_json = json.loads(spin_status)
 
         responses.post(
-            url=f"https://mysmob.api.connect.skoda-auto.cz/api/v1/spin/verify",
+            url="https://mysmob.api.connect.skoda-auto.cz/api/v1/spin/verify",
             body=spin_status,
         )
         get_spin_status_result = await myskoda.verify_spin(spin)
 
-        assert get_spin_status_result.verificationStatus == spin_status_json["verificationStatus"]
-        if get_spin_status_result.spinStatus is not None:
-            assert get_spin_status_result.spinStatus.remainingTries == spin_status_json["spinStatus"]["remainingTries"]
-            assert get_spin_status_result.spinStatus.lockedWaitingTimeInSeconds == spin_status_json["spinStatus"]["lockedWaitingTimeInSeconds"]
-            assert get_spin_status_result.spinStatus.state == spin_status_json["spinStatus"]["state"]
+        assert get_spin_status_result.verification_status == spin_status_json["verificationStatus"]
+        if get_spin_status_result.spin_status is not None:
+            assert (get_spin_status_result.spin_status.remaining_tries
+                    == spin_status_json["spinStatus"]["remainingTries"])
+            assert (get_spin_status_result.spin_status.locked_waiting_time_in_seconds
+                    == spin_status_json["spinStatus"]["lockedWaitingTimeInSeconds"])
+            assert (get_spin_status_result.spin_status.state
+                    == spin_status_json["spinStatus"]["state"])


### PR DESCRIPTION
- Added auxiliary heater support (start/stop). For some reason progress is not published via MQTT so request is just send and not awaited for COMPLETED_SUCCESS status
- Added verify_spin method which returns `CORRECT_SPIN` or `INCORRECT_SPIN` and S-Pin status