### PR TITLE
Make fields of ServiceEventChargingData optional

### DIFF
--- a/myskoda/models/service_event.py
+++ b/myskoda/models/service_event.py
@@ -97,10 +97,16 @@ def _deserialize_time_to_finish(value: int | str) -> int | None:
 class ServiceEventChargingData(ServiceEventData):
     """Charging Data inside a Service Event."""
 
-    mode: ChargeMode = field(metadata=field_options(deserialize=_deserialize_mode))
-    state: ChargingState = field(metadata=field_options(deserialize=_deserialize_charging_state))
-    soc: int
-    charged_range: int = field(metadata=field_options(alias="chargedRange"))
+    mode: ChargeMode | None = field(
+        default=None,
+        metadata=field_options(deserialize=_deserialize_mode),
+    )
+    state: ChargingState | None = field(
+        default=None,
+        metadata=field_options(deserialize=_deserialize_charging_state),
+    )
+    soc: int | None = field(default=None)
+    charged_range: int | None = field(default=None, metadata=field_options(alias="chargedRange"))
     time_to_finish: int | None = field(
         default=None,
         metadata=field_options(alias="timeToFinish", deserialize=_deserialize_time_to_finish),


### PR DESCRIPTION
Superb iV (MY 2020) does not send any additional data in the charging-status-changed event so the exception happens and warning is printed in the logs.

This can be observed from logs:
```
2024-11-09 15:30:34.512 DEBUG (MainThread) [myskoda.mqtt] Received PUBLISH (d0, q0, r0, m0), '97bee240-dd09-4d56-8d8b-fbdfxxxxxxxx/TMBAXXXXXXXXXXXXX/service-event/charging', ...  (237 bytes)
2024-11-09 15:30:34.513 DEBUG (MainThread) [myskoda.mqtt] Message (service-event) received for TMBAXXXXXXXXXXXXX on topic charging: b'{"version":1,"traceId":"81b50439-af83-44e1-9515-5b3925d4c34a","timestamp":"2024-11-09T13:30:34Z","producer":"SKODA_MHUB","name":"charging-status-changed","data":{"userId":"97bee240-dd09-4d56-8d8b-fbdfxxxxxxxx","vin":"TMBAXXXXXXXXXXXXX"}}'
2024-11-09 15:30:34.513 WARNING (MainThread) [myskoda.mqtt] Exception parsing MQTT event: Field "data" of type ServiceEventChargingData in ServiceEventCharging has invalid value {'userId': '97bee240-dd09-4d56-8d8b-fbdfxxxxxxxx', 'vin': 'TMBAXXXXXXXXXXXXX'}
2024-11-09 15:30:34.515 DEBUG (MainThread) [myskoda.mqtt] Received PUBLISH (d0, q0, r0, m0), '97bee240-dd09-4d56-8d8b-fbdfxxxxxxxx/TMBAXXXXXXXXXXXXX/service-event/charging', ...  (237 bytes)
2024-11-09 15:30:34.516 DEBUG (MainThread) [myskoda.mqtt] Message (service-event) received for TMBAXXXXXXXXXXXXX on topic charging: b'{"version":1,"traceId":"81b50439-af83-44e1-9515-5b3925d4c34a","timestamp":"2024-11-09T13:30:34Z","producer":"SKODA_MHUB","name":"charging-status-changed","data":{"userId":"97bee240-dd09-4d56-8d8b-fbdfxxxxxxxx","vin":"TMBAXXXXXXXXXXXXX"}}'
2024-11-09 15:30:34.516 WARNING (MainThread) [myskoda.mqtt] Exception parsing MQTT event: Field "data" of type ServiceEventChargingData in ServiceEventCharging has invalid value {'userId': '97bee240-dd09-4d56-8d8b-fbdfxxxxxxxx', 'vin': 'TMBAXXXXXXXXXXXXX'}
```