### PR TITLE
Some fields are not present in Superb iV 2020 response to driving_range

### DIFF
--- a/myskoda/models/driving_range.py
+++ b/myskoda/models/driving_range.py
@@ -17,10 +17,12 @@ class EngineType(StrEnum):
 
 @dataclass
 class EngineRange(DataClassORJSONMixin):
-    current_soc_in_percent: int = field(metadata=field_options(alias="currentSoCInPercent"))
     engine_type: EngineType = field(metadata=field_options(alias="engineType"))
     current_fuel_level_in_percent: int | None = field(
         default=None, metadata=field_options(alias="currentFuelLevelInPercent")
+    )
+    current_soc_in_percent: int | None = field(
+        default=None, metadata=field_options(alias="currentSoCInPercent")
     )
     remaining_range_in_km: int | None = field(
         default=None, metadata=field_options(alias="remainingRangeInKm")

--- a/myskoda/models/driving_range.py
+++ b/myskoda/models/driving_range.py
@@ -31,11 +31,9 @@ class EngineRange(DataClassORJSONMixin):
 
 @dataclass
 class DrivingRange(DataClassORJSONMixin):
+    car_captured_timestamp: datetime = field(metadata=field_options(alias="carCapturedTimestamp"))
     car_type: EngineType = field(metadata=field_options(alias="carType"))
     primary_engine_range: EngineRange = field(metadata=field_options(alias="primaryEngineRange"))
-    car_captured_timestamp: datetime | None = field(
-        default=None, metadata=field_options(alias="carCapturedTimestamp")
-    )
     secondary_engine_range: EngineRange | None = field(
         default=None, metadata=field_options(alias="secondaryEngineRange")
     )

--- a/myskoda/models/driving_range.py
+++ b/myskoda/models/driving_range.py
@@ -31,9 +31,11 @@ class EngineRange(DataClassORJSONMixin):
 
 @dataclass
 class DrivingRange(DataClassORJSONMixin):
-    car_captured_timestamp: datetime = field(metadata=field_options(alias="carCapturedTimestamp"))
     car_type: EngineType = field(metadata=field_options(alias="carType"))
     primary_engine_range: EngineRange = field(metadata=field_options(alias="primaryEngineRange"))
+    car_captured_timestamp: datetime | None = field(
+        default=None, metadata=field_options(alias="carCapturedTimestamp")
+    )
     secondary_engine_range: EngineRange | None = field(
         default=None, metadata=field_options(alias="secondaryEngineRange")
     )


### PR DESCRIPTION
Log entries:

```
2024-11-13 00:49:12.301 ERROR (MainThread) [myskoda.rest_api] Failed to deserialize data: {"carType":"hybrid","totalRangeInKm":770,"primaryEngineRange":{"engineType":"gasoline","currentSoCInPercent":93,"currentFuelLevelInPercent":93,"remainingRangeInKm":770},"secondaryEngineRange":{"engineType":"electric","remainingRangeInKm":0},"carCapturedTimestamp":"2024-11-12T17:54:48Z"}
Traceback (most recent call last):
  File "<string>", line 31, in __mashumaro_from_json__
  File "<string>", line 7, in __mashumaro_from_dict_json__
mashumaro.exceptions.MissingField: Field "current_soc_in_percent" of type int is missing in EngineRange instance

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/myskoda/rest_api.py", line 435, in _deserialize
    data = deserialize(text)
           ^^^^^^^^^^^^^^^^^
  File "<string>", line 33, in __mashumaro_from_json__
mashumaro.exceptions.InvalidFieldValue: Field "secondary_engine_range" of type Optional[EngineRange] in DrivingRange has invalid value {'engineType': 'electric', 'remainingRangeInKm': 0}
2024-11-13 00:49:12.302 ERROR (MainThread) [custom_components.myskoda.coordinator] Unexpected error fetching myskoda data
Traceback (most recent call last):
  File "<string>", line 31, in __mashumaro_from_json__
  File "<string>", line 7, in __mashumaro_from_dict_json__
mashumaro.exceptions.MissingField: Field "current_soc_in_percent" of type int is missing in EngineRange instance

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 382, in _async_refresh
    [self.data](http://self.data/) = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/myskoda/coordinator.py", line 94, in _async_update_data
    vehicle = await self.myskoda.get_vehicle(self.vin)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/myskoda/myskoda.py", line 311, in get_vehicle
    vehicle.driving_range = await self.get_driving_range(vin)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/myskoda/myskoda.py", line 277, in get_driving_range
    return (await self.rest_api.get_driving_range(vin, anonymize=anonymize)).result
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/myskoda/rest_api.py", line 191, in get_driving_range
    result = self._deserialize(raw, DrivingRange.from_json)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/myskoda/rest_api.py", line 435, in _deserialize
    data = deserialize(text)
           ^^^^^^^^^^^^^^^^^
  File "<string>", line 33, in __mashumaro_from_json__
mashumaro.exceptions.InvalidFieldValue: Field "secondary_engine_range" of type Optional[EngineRange] in DrivingRange has invalid value {'engineType': 'electric', 'remainingRangeInKm': 0}
2024-11-13 00:49:12.306 DEBUG (MainThread) [custom_components.myskoda.coordinator] Finished fetching myskoda data in 2.144 seconds (success: False)
```

And another one:
```
2024-11-13 01:09:25.294 DEBUG (MainThread) [myskoda.myskoda] Trace: GET https://mysmob.api.connect.skoda-auto.cz/api/v2/vehicle-stat - response: 200 (2 bytes) {}
2024-11-13 01:09:25.299 ERROR (MainThread) [myskoda.rest_api] Failed to deserialize data: {}
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/myskoda/rest_api.py", line 435, in _deserialize
    data = deserialize(text)
           ^^^^^^^^^^^^^^^^^
  File "<string>", line 8, in __mashumaro_from_json__
mashumaro.exceptions.MissingField: Field "car_captured_timestamp" of type datetime is missing in DrivingRange instance
2024-11-13 01:09:25.308 ERROR (MainThread) [custom_components.myskoda.coordinator] Unexpected error fetching myskoda data
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 382, in _async_refresh
    [self.data](http://self.data/) = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/myskoda/coordinator.py", line 94, in _async_update_data
    vehicle = await self.myskoda.get_vehicle(self.vin)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/myskoda/myskoda.py", line 311, in get_vehicle
    vehicle.driving_range = await self.get_driving_range(vin)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/myskoda/myskoda.py", line 277, in get_driving_range
    return (await self.rest_api.get_driving_range(vin, anonymize=anonymize)).result
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/myskoda/rest_api.py", line 191, in get_driving_range
    result = self._deserialize(raw, DrivingRange.from_json)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/myskoda/rest_api.py", line 435, in _deserialize
    data = deserialize(text)
           ^^^^^^^^^^^^^^^^^
  File "<string>", line 8, in __mashumaro_from_json__
mashumaro.exceptions.MissingField: Field "car_captured_timestamp" of type datetime is missing in DrivingRange instance
2024-11-13 01:09:25.311 DEBUG (MainThread) [custom_components.myskoda.coordinator] Finished fetching myskoda data in 3.150 seconds (success: False)
```