### PR TITLE
Create ability to define structures per service event

### DIFF
--- a/myskoda/event.py
+++ b/myskoda/event.py
@@ -8,7 +8,7 @@ from typing import Literal
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 from .models.operation_request import OperationRequest
-from .models.service_event import ServiceEvent, ServiceEventCharging
+from .models.service_event import ServiceEvent
 
 
 class ServiceEventTopic(StrEnum):
@@ -51,7 +51,7 @@ class EventAirConditioning(BaseEvent):
 
 @dataclass
 class EventCharging(BaseEvent):
-    event: ServiceEventCharging
+    event: ServiceEvent
     type: Literal[EventType.SERVICE_EVENT] = EventType.SERVICE_EVENT
     topic: Literal[ServiceEventTopic.CHARGING] = ServiceEventTopic.CHARGING
 

--- a/myskoda/mqtt.py
+++ b/myskoda/mqtt.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 import aiomqtt
 
 from myskoda.auth.authorization import Authorization
-from myskoda.models.service_event import ServiceEvent, ServiceEventCharging
+from myskoda.models.service_event import ServiceEvent
 
 from .const import (
     MQTT_ACCOUNT_EVENT_TOPICS,
@@ -228,7 +228,7 @@ class MySkodaMqttClient:
                         vin=vin,
                         user_id=user_id,
                         timestamp=datetime.now(tz=UTC),
-                        event=ServiceEventCharging.from_json(data),
+                        event=ServiceEvent.from_json(data),
                     )
                 )
             elif event_type == EventType.SERVICE_EVENT and topic == "departure":

--- a/tests/fixtures/events/service_event_charging_change_soc.json
+++ b/tests/fixtures/events/service_event_charging_change_soc.json
@@ -1,0 +1,16 @@
+{
+    "version": 1,
+    "traceId": "b03c66fe-67c5-4cd1-b50f-3c551078f6d0",
+    "timestamp": "2024-11-09T15:04:48Z",
+    "producer": "SKODA_MHUB",
+    "name": "change-soc",
+    "data": {
+        "mode": "manual",
+        "state": "charging",
+        "soc": "50",
+        "chargedRange": "195",
+        "timeToFinish": "440",
+        "userId": "ad0d7945-4814-43d0-801f-change-soc",
+        "vin": "TMBAXXXXXXXXXXXXX"
+    }
+}

--- a/tests/fixtures/events/service_event_charging_charging_status_changed.json
+++ b/tests/fixtures/events/service_event_charging_charging_status_changed.json
@@ -1,0 +1,11 @@
+{
+    "version": 1,
+    "traceId": "81b50439-af83-44e1-9515-5b3925d4c34a",
+    "timestamp": "2024-11-09T13:30:34Z",
+    "producer": "SKODA_MHUB",
+    "name": "charging-status-changed",
+    "data": {
+        "userId": "ad0d7945-4814-43d0-801f-charging-status-changed",
+        "vin": "TMBAXXXXXXXXXXXXX"
+    }
+}

--- a/tests/fixtures/events/service_event_departure.json
+++ b/tests/fixtures/events/service_event_departure.json
@@ -1,0 +1,11 @@
+{
+    "version": 1,
+    "traceId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "timestamp": "2024-11-15T13:14:41Z",
+    "producer": "SKODA_MHUB",
+    "name": "departure-status-changed",
+    "data": {
+        "userId": "ad0d7945-4814-43d0-801f-departure-status-changed",
+        "vin": "TMBAXXXXXXXXXXXXX"
+    }
+}

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -14,8 +14,10 @@ from myskoda.event import Event, EventAccess, EventCharging, EventLights, EventO
 from myskoda.models.charging import ChargeMode, ChargingState
 from myskoda.models.operation_request import OperationName, OperationRequest, OperationStatus
 from myskoda.models.service_event import (
-    ServiceEvent,
-    ServiceEventCharging,
+    ServiceEventChangeAccess,
+    ServiceEventChangeLights,
+    ServiceEventChangeSoc,
+    ServiceEventChargingCompleted,
     ServiceEventChargingData,
     ServiceEventData,
     ServiceEventName,
@@ -188,7 +190,7 @@ async def test_subscribe_event(
             vin=VIN,
             user_id=USER_ID,
             timestamp=ANY,
-            event=ServiceEvent(
+            event=ServiceEventChangeLights(
                 version=1,
                 trace_id=trace_id,
                 timestamp=timestamp,
@@ -201,7 +203,7 @@ async def test_subscribe_event(
             vin=VIN,
             user_id=USER_ID,
             timestamp=ANY,
-            event=ServiceEvent(
+            event=ServiceEventChangeAccess(
                 version=1,
                 trace_id=trace_id,
                 timestamp=timestamp,
@@ -214,7 +216,7 @@ async def test_subscribe_event(
             vin=VIN,
             user_id=USER_ID,
             timestamp=ANY,
-            event=ServiceEventCharging(
+            event=ServiceEventChangeSoc(
                 version=1,
                 trace_id=trace_id,
                 timestamp=timestamp,
@@ -235,7 +237,7 @@ async def test_subscribe_event(
             vin=VIN,
             user_id=USER_ID,
             timestamp=ANY,
-            event=ServiceEventCharging(
+            event=ServiceEventChargingCompleted(
                 version=1,
                 trace_id=trace_id,
                 timestamp=timestamp,

--- a/tests/test_service_event.py
+++ b/tests/test_service_event.py
@@ -1,0 +1,55 @@
+"""Unit tests for myskoda.models.service_event.
+
+This module partially repeats test_mqtt.py tests but is more isolated:
+here we have unit tests for service_event module only.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from myskoda.models.service_event import (
+    ChargeMode,
+    ChargingState,
+    ServiceEvent,
+    ServiceEventChargingData,
+    ServiceEventData,
+    ServiceEventName,
+)
+
+FIXTURES_DIR = Path(__file__).parent.joinpath("fixtures")
+
+
+@pytest.fixture(name="service_events")
+def load_service_events() -> list[str]:
+    """Load service_events fixture."""
+    service_events = []
+    for path in [
+        "events/service_event_charging_change_soc.json",
+        "events/service_event_charging_charging_status_changed.json",
+        "events/service_event_departure.json",
+    ]:
+        json_file = FIXTURES_DIR / path
+        service_events.append(json_file.read_text())
+    return service_events
+
+
+def test_parse_service_events(service_events: list[str]) -> None:
+    for service_event in service_events:
+        event = ServiceEvent.from_json(service_event)
+
+        if event.name == ServiceEventName.CHANGE_SOC:
+            assert event.data == ServiceEventChargingData(
+                charged_range=195,
+                mode=ChargeMode.MANUAL,
+                soc=50,
+                state=ChargingState.CHARGING,
+                time_to_finish=440,
+                user_id="ad0d7945-4814-43d0-801f-change-soc",
+                vin="TMBAXXXXXXXXXXXXX",
+            )
+        else:
+            assert event.data == ServiceEventData(
+                user_id=f"ad0d7945-4814-43d0-801f-{event.name.value}",
+                vin="TMBAXXXXXXXXXXXXX",
+            )


### PR DESCRIPTION
The structures are discriminated based on the "name" field in the received event.

I have tried to test this change on my Superb iV but apparently the car does not really send much events. I would appreciate if this  change is tested by someone.

Fixes #184