### PR TITLE
Switch to dynamic module versioning

### DIFF
--- a/myskoda/__init__.py
+++ b/myskoda/__init__.py
@@ -1,5 +1,6 @@
 """A library for interacting with the MySkoda APIs."""
 
+from .__version__ import __version__ as version
 from .auth.authorization import (
     Authorization,
     AuthorizationError,
@@ -25,24 +26,26 @@ from .rest_api import RestApi
 from .vehicle import Vehicle
 
 __all__ = [
+    "TRACE_CONFIG",
     "Authorization",
     "AuthorizationError",
     "AuthorizationFailedError",
     "IDKAuthorizationCode",
     "IDKSession",
+    "MySkoda",
+    "MySkodaMqttClient",
+    "RestApi",
+    "Vehicle",
     "air_conditioning",
     "charging",
     "common",
     "health",
     "info",
-    "position",
-    "status",
-    "RestApi",
-    "MySkoda",
     "operation_request",
+    "position",
     "service_event",
-    "MySkodaMqttClient",
-    "Vehicle",
+    "status",
     "user",
-    "TRACE_CONFIG",
 ]
+
+__version__ = version

--- a/myskoda/__init__.py
+++ b/myskoda/__init__.py
@@ -1,6 +1,6 @@
 """A library for interacting with the MySkoda APIs."""
 
-from .__version__ import __version__ as version
+from .__version__ import __version__
 from .auth.authorization import (
     Authorization,
     AuthorizationError,
@@ -36,6 +36,7 @@ __all__ = [
     "MySkodaMqttClient",
     "RestApi",
     "Vehicle",
+    "__version__",
     "air_conditioning",
     "charging",
     "common",
@@ -46,5 +47,4 @@ __all__ = [
     "service_event",
     "status",
     "user",
-    "__version__",
 ]

--- a/myskoda/__init__.py
+++ b/myskoda/__init__.py
@@ -46,6 +46,5 @@ __all__ = [
     "service_event",
     "status",
     "user",
+    "__version__",
 ]
-
-__version__ = version

--- a/myskoda/__version__.py
+++ b/myskoda/__version__.py
@@ -1,0 +1,3 @@
+"""Version for MySkoda package. Used for dynamic versioning with poetry."""
+
+__version__ = "0.0.0"

--- a/myskoda/models/maintenance.py
+++ b/myskoda/models/maintenance.py
@@ -13,9 +13,7 @@ from .common import Address, Coordinates, Weekday
 @dataclass
 class MaintenanceReport(DataClassORJSONMixin):
     captured_at: datetime = field(metadata=field_options(alias="capturedAt"))
-    mileage_in_km: int | None = field(
-        default=None, metadata=field_options(alias="mileageInKm")
-    )
+    mileage_in_km: int | None = field(default=None, metadata=field_options(alias="mileageInKm"))
     inspection_due_in_days: int | None = field(
         default=None, metadata=field_options(alias="inspectionDueInDays")
     )
@@ -79,9 +77,7 @@ class ServicePartner(DataClassORJSONMixin):
     id: str
     location: Coordinates
     name: str
-    opening_hours: list[OpeningHoursPeriod] = field(
-        metadata=field_options(alias="openingHours")
-    )
+    opening_hours: list[OpeningHoursPeriod] = field(metadata=field_options(alias="openingHours"))
     partner_number: str = field(metadata=field_options(alias="partnerNumber"))
 
 

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -7,7 +7,6 @@ import logging
 from asyncio import gather
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
-from importlib.metadata import version
 from ssl import SSLContext
 from traceback import format_exc
 from types import SimpleNamespace
@@ -25,6 +24,7 @@ from myskoda.models.fixtures import (
     create_fixture_vehicle,
 )
 
+from .__version__ import __version__ as version
 from .auth.authorization import Authorization
 from .event import Event
 from .models.air_conditioning import (
@@ -398,7 +398,6 @@ class MySkoda:
                 result=result.result.to_dict(),
             )
 
-
     async def get_endpoint(
         self, vin: str, endpoint: Endpoint, anonymize: bool = False
     ) -> GetEndpointResult[Any]:
@@ -426,7 +425,6 @@ class MySkoda:
         # Call the method and return the result
         return await method(vin, anonymize=anonymize)
 
-
     async def generate_get_fixture(
         self, name: str, description: str, vins: list[str], endpoint: Endpoint
     ) -> Fixture:
@@ -453,7 +451,7 @@ class MySkoda:
             generation_time=datetime.now(tz=UTC),
             vehicles=[vehicle for (_, vehicle) in vehicles],
             reports=reports,
-            library_version=version("MySkoda"),
+            library_version=version,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "myskoda"
-version = "0.13.0"
+version = "0.0.0"
 description = "Library for interaction with the MySkoda APIs."
 authors = [
     "Frederick Gnodtke <frederick@gnodtke.net>",
@@ -44,9 +44,14 @@ myskoda = "myskoda.cli:cli"
 cli = ["asyncclick", "coloredlogs", "termcolor", "pygments"]
 docs = ["mkdocs", "mkdocstrings", "mkdocs-gen-files", "mkdocs-literate-nav"]
 
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "semver"
+
 [build-system]
-build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
This PR does two things:

1) Introduce dynamic versioning from git tags
2) Fix skodaconnect/homeassistant-myskoda#353 by removing the blocking module

This means the version is dynamically placed inside `myskoda/__version__.py` by poetry when building the module. We alsno no longer need to bump the version in `pyproject.toml`

The version is now obtained from the latest tag or commit