### PR TITLE
Introduce exponential backoff for MQTT reconnect

### DIFF
--- a/myskoda/mqtt.py
+++ b/myskoda/mqtt.py
@@ -100,6 +100,7 @@ class MySkodaMqttClient:
         self._listener_task = None
         self._running = False
         self._subscribed = asyncio.Event()
+        self._reconnect_delay = MQTT_RECONNECT_DELAY
 
     async def connect(self, user_id: str, vehicle_vins: list[str]) -> None:
         """Connect to the MQTT broker and listen for messages for the given user_id and VINs."""
@@ -143,7 +144,6 @@ class MySkodaMqttClient:
         _LOGGER.debug("Starting _connect_and_listen")
         self._running = True
         while self._running:
-            self._reconnect_delay = MQTT_RECONNECT_DELAY
             try:
                 async with aiomqtt.Client(
                     hostname=self.hostname,
@@ -167,6 +167,7 @@ class MySkodaMqttClient:
                             await client.subscribe(f"{self.user_id}/{vin}/account-event/{topic}")
 
                     self._subscribed.set()
+                    self._reconnect_delay = MQTT_RECONNECT_DELAY
                     async for message in client.messages:
                         self._on_message(message)
             except aiomqtt.MqttError as exc:

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -132,7 +132,7 @@ class MySkoda:
             user = await self.get_user()
             vehicles = await self.list_vehicle_vins()
             await self.mqtt.connect(user.id, vehicles)
-        _LOGGER.debug("Myskoda ready.")
+        _LOGGER.debug("MySkoda ready.")
 
     def subscribe(self, callback: Callable[[Event], None | Awaitable[None]]) -> None:
         """Listen for events emitted by MySkoda's MQTT broker."""


### PR DESCRIPTION
This makes MQTT reconnect backoff exponential so we do not hammer MQTT server if it is in an error state.

Observed in todays MQTT outage that we reconnect every 5s, which is very rapid when running this distributed and at scale. 
We do not need to DOS the MQTT server while trying to get our updates, so implementing an industry-standard solution (exponential backoff with jitter) to this, seems like a reasonable addition.