### PR TITLE
Fix charging-completed event

### DIFF
--- a/myskoda/models/service_event.py
+++ b/myskoda/models/service_event.py
@@ -161,7 +161,11 @@ class ServiceEventChargingCompleted(ServiceEvent):
     """Event class for charging-completed service event."""
 
     name = ServiceEventName.CHARGING_COMPLETED
-    data: ServiceEventChargingData
+    # ServiceEventChargingData should be given first in the union list
+    # because the ServiceEventData is a subset of the ServiceEventChargingData
+    # and will be recognized as valid parser but then it will miss the rest of
+    # the data
+    data: ServiceEventChargingData | ServiceEventData
 
 
 class ServiceEventChargingStatusChanged(ServiceEvent):

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -158,6 +158,22 @@ async def test_subscribe_event(
                 }
             ),
         ),
+        (
+            f"{base_topic}/service-event/charging",
+            json.dumps(
+                {
+                    "version": 1,
+                    "traceId": trace_id,
+                    "timestamp": timestamp_str,
+                    "producer": "SKODA_MHUB",
+                    "name": "charging-completed",
+                    "data": {
+                        "userId": USER_ID,
+                        "vin": VIN,
+                    },
+                }
+            ),
+        ),
     ]
 
     def on_event(event: Event) -> None:
@@ -251,6 +267,22 @@ async def test_subscribe_event(
                     state=ChargingState.CONSERVING,
                     mode=ChargeMode.MANUAL,
                     time_to_finish=0,
+                ),
+            ),
+        ),
+        EventCharging(
+            vin=VIN,
+            user_id=USER_ID,
+            timestamp=ANY,
+            event=ServiceEventChargingCompleted(
+                version=1,
+                trace_id=trace_id,
+                timestamp=timestamp,
+                producer="SKODA_MHUB",
+                name=ServiceEventName.CHARGING_COMPLETED,
+                data=ServiceEventData(
+                    user_id=USER_ID,
+                    vin=VIN,
                 ),
             ),
         ),


### PR DESCRIPTION
Seems, in different versions of the car SW the event might contain or might not contain additional data. I can provide additional logs later (from Superb iV 2020), currently those are vanished after few reboots of the HA.