### PR TITLE
Add exception for redirect to marketing consent

### DIFF
--- a/myskoda/auth/authorization.py
+++ b/myskoda/auth/authorization.py
@@ -164,7 +164,7 @@ class Authorization:
                     if "terms-and-conditions" in location:
                         raise TermsAndConditionsError(location)
                     if "consent/marketing" in location:
-                        raise MarketingConstentError(location)
+                        raise MarketingConsentError(location)
                     async with self.session.get(location, allow_redirects=False) as response:
                         location = response.headers["Location"]
                 codes = location.replace("myskoda://redirect/login/#", "")
@@ -327,5 +327,5 @@ class AuthorizationFailedError(Exception):
 class TermsAndConditionsError(Exception):
     """Redirect to Terms and Conditions was encountered."""
 
-class MarketingConstentError(Exception):
+class MarketingConsentError(Exception):
     """Redirect to Marketing Consent encountered."""

--- a/myskoda/auth/authorization.py
+++ b/myskoda/auth/authorization.py
@@ -163,6 +163,8 @@ class Authorization:
                 while not location.startswith("myskoda://"):
                     if "terms-and-conditions" in location:
                         raise TermsAndConditionsError(location)
+                    if "consent/marketing" in location:
+                        raise MarketingConstentError(location)
                     async with self.session.get(location, allow_redirects=False) as response:
                         location = response.headers["Location"]
                 codes = location.replace("myskoda://redirect/login/#", "")
@@ -324,3 +326,6 @@ class AuthorizationFailedError(Exception):
 
 class TermsAndConditionsError(Exception):
     """Redirect to Terms and Conditions was encountered."""
+
+class MarketingConstentError(Exception):
+    """Redirect to Marketing Consent encountered."""


### PR DESCRIPTION
during login the process can halt because the user is redirected to a marketing constent page. Without catching this condition a KeyError Location is raised because it's the final page but doesn't start with `myskoda://`.

Ref #277 