### PR TITLE
Add set-minimum-charge-limit feature

### DIFF
--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -28,7 +28,7 @@
 | sonar98 | POST   | api/v1/authentication/revoke-token                                         |       |         |
 | sonar98 | GET    | api/v1/vehicle-automatization/{vin}/departure/timers                       |       |         |
 | sonar98 | POST   | api/v1/vehicle-automatization/{vin}/departure/timers                       |       |         |
-| sonar98 | POST   | api/v1/vehicle-automatization/{vin}/departure/timers/settings              |       |         |
+| sonar98 | POST   | api/v1/vehicle-automatization/{vin}/departure/timers/settings              | ✅      |         |
 | sonar98 | GET    | api/v1/discover-news                                                       |       |         |
 | sonar98 | GET    | api/v1/service-partners/{servicePartnerId}/encoded-url                     |       |         |
 | sonar98 | GET    | api/v1/service-partners                                                    |       |         |

--- a/myskoda/cli/__init__.py
+++ b/myskoda/cli/__init__.py
@@ -25,6 +25,7 @@ from myskoda.cli.operations import (
     set_auto_unlock_plug,
     set_charge_limit,
     set_departure_timer,
+    set_minimum_charge_limit,
     set_reduced_current_limit,
     set_seats_heating,
     set_target_temperature,
@@ -160,6 +161,7 @@ cli.add_command(set_target_temperature)
 cli.add_command(start_window_heating)
 cli.add_command(stop_window_heating)
 cli.add_command(set_charge_limit)
+cli.add_command(set_minimum_charge_limit)
 cli.add_command(set_reduced_current_limit)
 cli.add_command(wakeup)
 cli.add_command(wait_for_operation)

--- a/myskoda/cli/operations.py
+++ b/myskoda/cli/operations.py
@@ -160,6 +160,19 @@ async def set_charge_limit(ctx: Context, timeout: float, vin: str, limit: int) -
 @click.command()
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
+@click.option("limit", "--limit", type=float, required=True)
+@click.pass_context
+@mqtt_required
+async def set_minimum_charge_limit(ctx: Context, timeout: float, vin: str, limit: int) -> None:  # noqa: ASYNC109
+    """Set the minimum charge limit in percent."""
+    myskoda: MySkoda = ctx.obj["myskoda"]
+    async with asyncio.timeout(timeout):
+        await myskoda.set_minimum_charge_limit(vin, limit)
+
+
+@click.command()
+@click.option("timeout", "--timeout", type=float, default=300)
+@click.argument("vin")
 @click.option("enabled", "--enabled", type=bool, required=True)
 @click.pass_context
 @mqtt_required

--- a/myskoda/const.py
+++ b/myskoda/const.py
@@ -29,6 +29,7 @@ MQTT_OPERATION_TOPICS = [
     "charging/update-charging-profiles",
     "charging/update-charging-current",
     "departure/update-departure-timers",
+    "departure/update-minimal-soc",
     "vehicle-access/honk-and-flash",
     "vehicle-access/lock-vehicle",
     "vehicle-services-backup/apply-backup",

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -206,6 +206,12 @@ class MySkoda:
         await self.rest_api.set_charge_limit(vin, limit)
         await future
 
+    async def set_minimum_charge_limit(self, vin: str, limit: int) -> None:
+        """Set minimum battery SoC in percent for departure timer."""
+        future = self._wait_for_operation(OperationName.UPDATE_MINIMAL_SOC)
+        await self.rest_api.set_minimum_charge_limit(vin, limit)
+        await future
+
     async def stop_window_heating(self, vin: str) -> None:
         """Stop heating both the front and rear window."""
         future = self._wait_for_operation(OperationName.STOP_WINDOW_HEATING)

--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -423,6 +423,20 @@ class RestApi:
             json=json_data,
         )
 
+    async def set_minimum_charge_limit(self, vin: str, limit: int) -> None:
+        """Set minimum battery SoC in percent for departure timer."""
+        _LOGGER.debug(
+            "Setting minimum SoC for departure timers for vehicle %s to %r",
+            vin,
+            limit,
+        )
+
+        json_data = {"minimumBatteryStateOfChargeInPercent": limit}
+        await self._make_post_request(
+            url=f"/v1/vehicle-automatization/{vin}/departure/timers/settings",
+            json=json_data,
+        )
+
     # TODO @dvx76: Maybe refactor for FBT001
     async def set_battery_care_mode(self, vin: str, enabled: bool) -> None:
         """Enable or disable the battery care mode."""


### PR DESCRIPTION
Part of departure timers - used when there is at least 1 active timer. Car will charge to the specified SoC after connecting charging cable and stop charging when specified SoC is reached. Rest is charged using departure timer rules. 