### PR TITLE
fix(cli): missing await in auth command

### DIFF
--- a/myskoda/cli/requests.py
+++ b/myskoda/cli/requests.py
@@ -147,4 +147,4 @@ async def departure_timers(ctx: Context, vin: str, anonymize: bool) -> None:
 async def auth(ctx: Context) -> None:
     """Extract the auth token."""
     myskoda: MySkoda = ctx.obj["myskoda"]
-    print(myskoda.get_auth_token())
+    print(await myskoda.get_auth_token())


### PR DESCRIPTION
Fixes:

```sh
$ myskoda --user <MYSKODA_EMAIL> --password <MYSKODA_PASSWORD> auth
<coroutine object MySkoda.get_auth_token at 0x106921cc0>
./myskoda/myskoda/cli/requests.py:151: RuntimeWarning: coroutine 'MySkoda.get_auth_token' was never awaited
  print(myskoda.get_auth_token())
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```