### PR TITLE
Switch to static app_uuid to fix mqtt connection

### DIFF
--- a/myskoda/mqtt.py
+++ b/myskoda/mqtt.py
@@ -44,7 +44,7 @@ from .models.operation_request import OperationName, OperationRequest, Operation
 
 _LOGGER = logging.getLogger(__name__)
 TOPIC_RE = re.compile("^(.*?)/(.*?)/(.*?)/(.*?)$")
-app_uuid = uuid.uuid4()
+app_uuid = '2940a48-3881-43c2-be46-c4cf53e7fc7b'
 
 
 def _create_ssl_context() -> ssl.SSLContext:


### PR DESCRIPTION
it seems like the mqtt server rejects connections with different identifiers

Before
```
DEBUG:myskoda.myskoda:IDK Authorization was successful.
INFO:myskoda.mqtt:Connecting to MQTT with .../['...']
DEBUG:myskoda.mqtt:Starting _connect_and_listen
DEBUG:myskoda.mqtt:Sending CONNECT (u1, p1, wr0, wq0, wf0, c1, k60) client_id=b'6d3eaefc-5408-4668-88b6-7e4bf50fa42f'
DEBUG:myskoda.mqtt:Received CONNACK (0, 5)
INFO:myskoda.mqtt:Connection lost ([code:5] The connection was refused.); reconnecting in 5s
DEBUG:myskoda.mqtt:Sending CONNECT (u1, p1, wr0, wq0, wf0, c1, k60) client_id=b'6d3eaefc-5408-4668-88b6-7e4bf50fa42f'
DEBUG:myskoda.mqtt:Received CONNACK (0, 5)
INFO:myskoda.mqtt:Connection lost ([code:5] The connection was refused.); reconnecting in 5s
DEBUG:myskoda.mqtt:Sending CONNECT (u1, p1, wr0, wq0, wf0, c1, k60) client_id=b'6d3eaefc-5408-4668-88b6-7e4bf50fa42f'
DEBUG:myskoda.mqtt:Received CONNACK (0, 5)
INFO:myskoda.mqtt:Connection lost ([code:5] The connection was refused.); reconnecting in 5s
^CTraceback (most recent call last):
```

Afterwards
```
DEBUG:myskoda.myskoda:IDK Authorization was successful.
INFO:myskoda.mqtt:Connecting to MQTT with .../['...']
DEBUG:myskoda.mqtt:Starting _connect_and_listen
DEBUG:myskoda.mqtt:Sending CONNECT (u1, p1, wr0, wq0, wf0, c1, k60) client_id=b'2940a48-3881-43c2-be46-c4cf53e7fc7b'
DEBUG:myskoda.mqtt:Received CONNACK (0, 0)
INFO:myskoda.mqtt:Connected to MQTT
```

uuid taken from https://github.com/skodaconnect/myskoda/blob/664d98e1904dc3b1fd00d3344ace68bc71a2fd14/docs/mqtt.md