### PR TITLE
Fix CI tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,16 +11,8 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v4
 
-      # This has been done according to https://docs.makedeb.org/prebuilt-mpr/getting-started/
-      # This is needed for packages: just
-      - name: Add makedb debian user repository
-        run: |
-          curl -q 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
-          sudo apt update
-
       - name: Install dev dependencies
-        run: sudo apt install just
+        run: sudo snap install just --classic
 
       - name: Install Poetry
         run: pipx install poetry


### PR DESCRIPTION
The apt repository we're using for installing `Just` has been showing issues lately.

This is now swapped with the snap alternative.