### PR TITLE
add missing errors object into Capabilities object

### DIFF
--- a/fixtures/citigoe_iv_2020_ne132e2.yaml
+++ b/fixtures/citigoe_iv_2020_ne132e2.yaml
@@ -183,6 +183,7 @@ reports:
             statuses: []
           - id: AIR_CONDITIONING
             statuses: []
+        errors: null 
       renders: []
       device_platform: MBB
       workshop_mode_enabled: false

--- a/fixtures/citigoe_iv_2020_ne14e2_style.yaml
+++ b/fixtures/citigoe_iv_2020_ne14e2_style.yaml
@@ -189,6 +189,7 @@ reports:
             statuses: []
           - id: AIR_CONDITIONING
             statuses: []
+        errors: null 
       renders: []
       device_platform: MBB
       workshop_mode_enabled: false

--- a/fixtures/citigoe_iv_2021_ne142e2_best_of.yaml
+++ b/fixtures/citigoe_iv_2021_ne142e2_best_of.yaml
@@ -92,6 +92,7 @@ reports:
         statuses: []
       - id: AIR_CONDITIONING
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/djapollo_enyaq_85_5AZJK2.yaml
+++ b/fixtures/djapollo_enyaq_85_5AZJK2.yaml
@@ -166,6 +166,7 @@ reports:
         statuses: []
       - id: ROUTE_PLANNING_10_CHARGERS
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/enyaq_2023_5AZJJ2_80.yaml
+++ b/fixtures/enyaq_2023_5AZJJ2_80.yaml
@@ -310,6 +310,7 @@ reports:
             statuses: []
           - id: VEHICLE_WAKE_UP_TRIGGER
             statuses: []
+        errors: null 
       renders: []
       device_platform: WCAR
       workshop_mode_enabled: false

--- a/fixtures/kamiq_2021_NW44KD_crossover.yaml
+++ b/fixtures/kamiq_2021_NW44KD_crossover.yaml
@@ -96,6 +96,7 @@ reports:
         statuses: []
       - id: MISUSE_PROTECTION
         statuses: []
+      errors: null
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/karoq_2022_nu74nv_se_l_expired_subscription.yaml
+++ b/fixtures/karoq_2022_nu74nv_se_l_expired_subscription.yaml
@@ -142,6 +142,7 @@ reports:
         statuses: []
       - id: CARE_AND_INSURANCE
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/karoq_2023_NU74MD_se_l.yaml
+++ b/fixtures/karoq_2023_NU74MD_se_l.yaml
@@ -101,6 +101,7 @@ reports:
         statuses: []
       - id: CARE_AND_INSURANCE
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/kodiaq_2023_NS74QZ_style.yaml
+++ b/fixtures/kodiaq_2023_NS74QZ_style.yaml
@@ -197,6 +197,7 @@ reports:
             statuses: []
           - id: CARE_AND_INSURANCE
             statuses: []
+        errors: null 
       renders:
         - url: https://iprenders.blob.core.windows.net/basens7v23200004/5X5XDSLGPW-65-Rvio3t1p5gk9_-8s1bgIP.oW_j3BxMlT-qfP3M.TJG0inswacXCg-B0vtg8.XZU6n1mbPqrJdN-OCJWIYSEALQV-19201080dayvext_side1080.png
           type: REAL

--- a/fixtures/kodiaq_2024_ps7d6z_exclusive.yaml
+++ b/fixtures/kodiaq_2024_ps7d6z_exclusive.yaml
@@ -125,6 +125,7 @@ reports:
         statuses: []
       - id: EXTENDED_CHARGING_SETTINGS
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/kodiaq_iv_2024_ps7dyc_selection.yaml
+++ b/fixtures/kodiaq_iv_2024_ps7dyc_selection.yaml
@@ -251,6 +251,7 @@ reports:
             statuses: []
           - id: EXTENDED_CHARGING_SETTINGS
             statuses: []
+        errors: null 
       renders: []
       device_platform: MBB_ODP
       workshop_mode_enabled: false

--- a/fixtures/octavia_2022.yaml
+++ b/fixtures/octavia_2022.yaml
@@ -120,6 +120,7 @@ reports:
         statuses: []
       - id: CARE_AND_INSURANCE
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/octavia_2023_NX34JD_style.yaml
+++ b/fixtures/octavia_2023_NX34JD_style.yaml
@@ -122,6 +122,7 @@ reports:
         statuses: []
       - id: CARE_AND_INSURANCE
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/octavia_2023_NX53L5_combi.yaml
+++ b/fixtures/octavia_2023_NX53L5_combi.yaml
@@ -112,6 +112,7 @@ reports:
         statuses: []
       - id: MISUSE_PROTECTION
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/octavia_2024_NX53L5_combi.yaml
+++ b/fixtures/octavia_2024_NX53L5_combi.yaml
@@ -118,6 +118,7 @@ reports:
         statuses: []
       - id: MISUSE_PROTECTION
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/octavia_iv_2021_nx56xc_combi_rs.yaml
+++ b/fixtures/octavia_iv_2021_nx56xc_combi_rs.yaml
@@ -276,6 +276,7 @@ reports:
             statuses: []
           - id: AIR_CONDITIONING
             statuses: []
+        errors: null 
       renders:
         - url: >-
             https://skodavinimagecache.blob.core.windows.net/cachenx5s21210312/9P9PsXOmK-cdS7FOILh.B-AhOm8JSdvpFn4XsbIf-5reFbkV3OA7tJ.whR_Nzd-i2DFKvp8Zy.SgfkLr3NIX5-CKUMHFODS-19201080dayvext_side1080.png

--- a/fixtures/octavia_iv_2022_nx34vc_liftback_style.yaml
+++ b/fixtures/octavia_iv_2022_nx34vc_liftback_style.yaml
@@ -266,6 +266,7 @@ reports:
             statuses: []
           - id: AIR_CONDITIONING
             statuses: []
+        errors: null 
       renders:
         - url: >-
             https://skodavinimagecache.blob.core.windows.net/cachenx3s22200316/8X8X4gqAbYIOe-i2DnaWx.ms6g-9BdYgTS5F_HJyjWb-clCgEXNvK_1i4QIswoY-.mPu_UpbAHEyMv4T61hBY0jk-EFCI-19201080dayvext_side1080.png

--- a/fixtures/prior99_enyaq_2024_5AZFF2_idle_full_battery.yaml
+++ b/fixtures/prior99_enyaq_2024_5AZFF2_idle_full_battery.yaml
@@ -156,6 +156,7 @@ reports:
         statuses: []
       - id: VEHICLE_WAKE_UP_TRIGGER
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/prior99_octavia_2018_5E535D_ambition.yaml
+++ b/fixtures/prior99_octavia_2018_5E535D_ambition.yaml
@@ -87,6 +87,7 @@ reports:
         statuses: []
       - id: VEHICLE_HEALTH_WARNINGS_WITH_WAKE_UP
         statuses: []
+      errors: null 
     composite_renders: []
     device_platform: MBB
     errors:

--- a/fixtures/sonar98_enyaq_2022_5AZJJ2.yaml
+++ b/fixtures/sonar98_enyaq_2022_5AZJJ2.yaml
@@ -157,6 +157,7 @@ reports:
         statuses: []
       - id: VEHICLE_WAKE_UP_TRIGGER
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/superb_2024_3v35wz_liftback_l_and_k.yaml
+++ b/fixtures/superb_2024_3v35wz_liftback_l_and_k.yaml
@@ -255,6 +255,7 @@ reports:
             statuses: []
           - id: AUXILIARY_HEATING_BASIC
             statuses: []
+        errors: null 
       renders:
         - url: >-
             https://iprenders.blob.core.windows.net/base3v3v23200002/0F0FWBQ-6-RemtP8.jqZy0-ZqEczfhG_n50.tUwX-CWwFuhHKJkNPz40df893ms-Has5qeWchF.UzAl13y8jCtnK-CKFEIA-19201080dayvext_front1080.png

--- a/fixtures/superb_iv_2020_3v35xc_liftback_l_and_k.yaml
+++ b/fixtures/superb_iv_2020_3v35xc_liftback_l_and_k.yaml
@@ -132,6 +132,7 @@ reports:
         statuses: []
       - id: AIR_CONDITIONING
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/superb_iv_2021_3v54xc.yaml
+++ b/fixtures/superb_iv_2021_3v54xc.yaml
@@ -141,6 +141,7 @@ reports:
         statuses: []
       - id: AIR_CONDITIONING
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/superb_iv_combi_2022_3V53XC_standing_still.yaml
+++ b/fixtures/superb_iv_combi_2022_3V53XC_standing_still.yaml
@@ -140,6 +140,7 @@ reports:
         statuses: []
       - id: AIR_CONDITIONING
         statuses: []
+      errors: null 
     composite_renders:
     - layers:
       - order: 0

--- a/fixtures/webspider_enyaq_2021_5AZJJ2.yaml
+++ b/fixtures/webspider_enyaq_2021_5AZJJ2.yaml
@@ -287,6 +287,7 @@ reports:
         statuses: []
       - id: VEHICLE_WAKE_UP_TRIGGER
         statuses: []
+      errors: null 
     renders: []
     device_platform: WCAR
     workshop_mode_enabled: false

--- a/myskoda/cli/gen_fixtures.py
+++ b/myskoda/cli/gen_fixtures.py
@@ -29,7 +29,7 @@ async def gen_fixtures(
     """Interact with the MySkoda API."""
     myskoda: MySkoda = ctx.obj["myskoda"]
 
-    default_filename = Path("fixtures") / f"{name.replace(" ", "_").lower()}.yaml"
+    default_filename = Path("fixtures") / f"{name.replace(' ', '_').lower()}.yaml"
 
     ctx.obj["vins"] = await get_vin_list(myskoda, vehicle)
     ctx.obj["name"] = name

--- a/myskoda/cli/mqtt.py
+++ b/myskoda/cli/mqtt.py
@@ -26,7 +26,7 @@ async def wait_for_operation(ctx: Context, operation: OperationName) -> None:
     if myskoda.mqtt is None:
         raise MqttDisabledError
 
-    print(f"Waiting for an operation {colored(operation,"green")} to start and complete...")
+    print(f"Waiting for an operation {colored(operation, 'green')} to start and complete...")
 
     await myskoda.mqtt.wait_for_operation(operation)
     print("Completed.")

--- a/myskoda/models/info.py
+++ b/myskoda/models/info.py
@@ -158,6 +158,7 @@ class Capabilities(DataClassORJSONMixin):
     capabilities: list[Capability] = field(
         metadata=field_options(deserialize=drop_unknown_capabilities)
     )
+    errors: list[Error] | None = field(default=None)
 
 
 @dataclass

--- a/tests/fixtures/superb/garage_with_429_error.json
+++ b/tests/fixtures/superb/garage_with_429_error.json
@@ -1,0 +1,233 @@
+{
+    "vin": "TMBJM0CKV1N12345",
+    "name": "Superb",
+    "workshopModeEnabled": false,
+    "licensePlate": "AB123CD",
+    "state": "ACTIVATED",
+    "devicePlatform": "MBB_ODP",
+    "specification": {
+        "title": "Škoda Superb Combi",
+        "manufacturingDate": "2020-03-05",
+        "model": "Superb",
+        "modelYear": "2020",
+        "body": "Combi",
+        "trimLevel": "L&K",
+        "systemCode": "UNKNOWN",
+        "systemModelId": "3V55XC",
+        "battery": {
+            "capacityInKWh": 13
+        },
+        "engine": {
+            "type": "TSI iV",
+            "powerInKW": 160,
+            "capacityInLiters": 1.4
+        },
+        "gearbox": {
+            "type": "A6F"
+        }
+    },
+    "servicePartner": {
+        "servicePartnerId": "XXXXXX"
+    },
+    "renders": [],
+    "compositeRenders": [
+        {
+            "layers": [
+                {
+                    "url": "https://iprenders.blob.core.windows.net/base3v5s20201119/8X8X-_ovsqZUlebk-6kVuox9bcY-24NgnyaQTw.qVlH-xIA7F_6aPQ2EYMU1f-s2BZqeSWgmR0K69.ltbHVNDwO-DiSFcULXOfePZlBGIn-19201080dayvext_front1080.png",
+                    "viewPoint": "exterior_front",
+                    "type": "REAL",
+                    "order": 0
+                }
+            ],
+            "viewType": "UNMODIFIED_EXTERIOR_FRONT"
+        },
+        {
+            "layers": [
+                {
+                    "url": "https://iprenders.blob.core.windows.net/base3v5s20201119/8X8X-_ovsqZUlebk-6kVuox9bcY-24NgnyaQTw.qVlH-xIA7F_6aPQ2EYMU1f-s2BZqeSWgmR0K69.ltbHVNDwO-DiSFcULXOfePZlBGIn-19201080dayvext_side1080.png",
+                    "viewPoint": "exterior_side",
+                    "type": "REAL",
+                    "order": 0
+                }
+            ],
+            "viewType": "UNMODIFIED_EXTERIOR_SIDE"
+        },
+        {
+            "layers": [
+                {
+                    "url": "https://iprenders.blob.core.windows.net/base3v5s20201119/8X8X-_ovsqZUlebk-6kVuox9bcY-24NgnyaQTw.qVlH-xIA7F_6aPQ2EYMU1f-s2BZqeSWgmR0K69.ltbHVNDwO-DiSFcULXOfePZlBGIn-19201080dayvext_side1080.png",
+                    "viewPoint": "exterior_side",
+                    "type": "REAL",
+                    "order": 0
+                }
+            ],
+            "modifications": {
+                "adjustSpaceInPx": {
+                    "top": -354,
+                    "bottom": -200,
+                    "left": -138,
+                    "right": -66
+                },
+                "densityIndependentHeight": 270,
+                "flipHorizontal": false,
+                "anchorTo": "LEFT"
+            },
+            "viewType": "HOME"
+        },
+        {
+            "layers": [
+                {
+                    "url": "https://iprenders.blob.core.windows.net/base3v5s20201119/8X8X-_ovsqZUlebk-6kVuox9bcY-24NgnyaQTw.qVlH-xIA7F_6aPQ2EYMU1f-s2BZqeSWgmR0K69.ltbHVNDwO-DiSFcULXOfePZlBGIn-19201080dayvext_front1080.png",
+                    "viewPoint": "exterior_front",
+                    "type": "REAL",
+                    "order": 0
+                },
+                {
+                    "url": "https://mspgwlivestorage.blob.core.windows.net/renders/cables/superb_3V_cable_charging_light_v1.png",
+                    "viewPoint": "exterior_front",
+                    "type": "REAL",
+                    "order": 1
+                }
+            ],
+            "modifications": {
+                "adjustSpaceInPx": {
+                    "top": -324,
+                    "bottom": -184,
+                    "left": -202,
+                    "right": -245
+                },
+                "densityIndependentHeight": 270,
+                "flipHorizontal": false,
+                "anchorTo": "RIGHT"
+            },
+            "viewType": "CHARGING_LIGHT"
+        },
+        {
+            "layers": [
+                {
+                    "url": "https://iprenders.blob.core.windows.net/base3v5s20201119/8X8X-_ovsqZUlebk-6kVuox9bcY-24NgnyaQTw.qVlH-xIA7F_6aPQ2EYMU1f-s2BZqeSWgmR0K69.ltbHVNDwO-DiSFcULXOfePZlBGIn-19201080dayvext_front1080.png",
+                    "viewPoint": "exterior_front",
+                    "type": "REAL",
+                    "order": 0
+                },
+                {
+                    "url": "https://mspgwlivestorage.blob.core.windows.net/renders/cables/superb_3V_cable_charging_dark_v1.png",
+                    "viewPoint": "exterior_front",
+                    "type": "REAL",
+                    "order": 1
+                }
+            ],
+            "modifications": {
+                "adjustSpaceInPx": {
+                    "top": -324,
+                    "bottom": -184,
+                    "left": -202,
+                    "right": -245
+                },
+                "densityIndependentHeight": 270,
+                "flipHorizontal": false,
+                "anchorTo": "RIGHT"
+            },
+            "viewType": "CHARGING_DARK"
+        },
+        {
+            "layers": [
+                {
+                    "url": "https://iprenders.blob.core.windows.net/base3v5s20201119/8X8X-_ovsqZUlebk-6kVuox9bcY-24NgnyaQTw.qVlH-xIA7F_6aPQ2EYMU1f-s2BZqeSWgmR0K69.ltbHVNDwO-DiSFcULXOfePZlBGIn-19201080dayvext_front1080.png",
+                    "viewPoint": "exterior_front",
+                    "type": "REAL",
+                    "order": 0
+                },
+                {
+                    "url": "https://mspgwlivestorage.blob.core.windows.net/renders/cables/superb_3V_cable_plugged_in_light_v1.png",
+                    "viewPoint": "exterior_front",
+                    "type": "REAL",
+                    "order": 1
+                }
+            ],
+            "modifications": {
+                "adjustSpaceInPx": {
+                    "top": -324,
+                    "bottom": -184,
+                    "left": -202,
+                    "right": -245
+                },
+                "densityIndependentHeight": 270,
+                "flipHorizontal": false,
+                "anchorTo": "RIGHT"
+            },
+            "viewType": "PLUGGED_IN_LIGHT"
+        },
+        {
+            "layers": [
+                {
+                    "url": "https://iprenders.blob.core.windows.net/base3v5s20201119/8X8X-_ovsqZUlebk-6kVuox9bcY-24NgnyaQTw.qVlH-xIA7F_6aPQ2EYMU1f-s2BZqeSWgmR0K69.ltbHVNDwO-DiSFcULXOfePZlBGIn-19201080dayvext_front1080.png",
+                    "viewPoint": "exterior_front",
+                    "type": "REAL",
+                    "order": 0
+                },
+                {
+                    "url": "https://mspgwlivestorage.blob.core.windows.net/renders/cables/superb_3V_cable_plugged_in_dark_v1.png",
+                    "viewPoint": "exterior_front",
+                    "type": "REAL",
+                    "order": 1
+                }
+            ],
+            "modifications": {
+                "adjustSpaceInPx": {
+                    "top": -324,
+                    "bottom": -184,
+                    "left": -202,
+                    "right": -245
+                },
+                "densityIndependentHeight": 270,
+                "flipHorizontal": false,
+                "anchorTo": "RIGHT"
+            },
+            "viewType": "PLUGGED_IN_DARK"
+        }
+    ],
+    "capabilities": {
+        "capabilities": [
+            {
+                "id": "LOYALTY_PROGRAM",
+                "statuses": []
+            },
+            {
+                "id": "SUBSCRIPTIONS",
+                "statuses": []
+            },
+            {
+                "id": "CAR_FEEDBACK",
+                "statuses": []
+            },
+            {
+                "id": "FLEET_SUPPORTED",
+                "statuses": []
+            },
+            {
+                "id": "LOYALTY_PROGRAM_WORLDWIDE",
+                "statuses": []
+            },
+            {
+                "id": "OUTSIDE_TEMPERATURE",
+                "statuses": []
+            },
+            {
+                "id": "SERVICE_PARTNER",
+                "statuses": []
+            },
+            {
+                "id": "MISUSE_PROTECTION",
+                "statuses": []
+            }
+        ],
+        "errors": [
+            {
+                "type": "UNAVAILABLE_SERVICE_PLATFORM_CAPABILITIES",
+                "description": "Get capabilities call to VDBS failed because of response code is {429 TOO_MANY_REQUESTS} for user {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx} and vehicle {TMBJM0CKV1N12345}"
+            }
+        ]
+    }
+}

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -584,7 +584,7 @@ async def test_set_ac_at_unlock(
 
     future = myskoda.set_ac_at_unlock(VIN, settings)
 
-    topic = f"{USER_ID}/{VIN}/operation-request/" "air-conditioning/set-air-conditioning-at-unlock"
+    topic = f"{USER_ID}/{VIN}/operation-request/air-conditioning/set-air-conditioning-at-unlock"
     await mqtt_client.publish(topic, create_completed_json("set-air-conditioning-at-unlock"), QOS_2)
 
     await future
@@ -616,7 +616,7 @@ async def test_set_windows_heating(
 
     future = myskoda.set_windows_heating(VIN, settings)
 
-    topic = f"{USER_ID}/{VIN}/operation-request/" "air-conditioning/windows-heating"
+    topic = f"{USER_ID}/{VIN}/operation-request/air-conditioning/windows-heating"
     await mqtt_client.publish(topic, create_completed_json("windows-heating"), QOS_2)
 
     await future
@@ -649,9 +649,7 @@ async def test_set_seats_heating(
 
     future = myskoda.set_seats_heating(VIN, settings)
 
-    topic = (
-        f"{USER_ID}/{VIN}/operation-request/" "air-conditioning/set-air-conditioning-seats-heating"
-    )
+    topic = f"{USER_ID}/{VIN}/operation-request/air-conditioning/set-air-conditioning-seats-heating"
     await mqtt_client.publish(
         topic, create_completed_json("set-air-conditioning-seats-heating"), QOS_2
     )

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -27,6 +27,7 @@ def load_vehicle_info() -> list[str]:
         "enyaq/garage_vehicles_iv80.json",
         "enyaq/garage_vehicles_iv80_coupe.json",
         "superb/garage_vehicles_LK_liftback.json",
+        "superb/garage_with_429_error.json",
     ]:
         with FIXTURES_DIR.joinpath(path).open() as file:
             vehicle_infos.append(file.read())


### PR DESCRIPTION
When testing API limit, I found out there is `TOO_MANY_REQUESTS` error returned from get-info endpoint but the error object was not yet serialized from the response.  

```JSON
{
    "capabilities": {
        "capabilities": [
            {
                "id": "LOYALTY_PROGRAM",
                "statuses": []
            },
            {
                "id": "SUBSCRIPTIONS",
                "statuses": []
            },
            {
                "id": "CAR_FEEDBACK",
                "statuses": []
            },
            {
                "id": "FLEET_SUPPORTED",
                "statuses": []
            },
            {
                "id": "LOYALTY_PROGRAM_WORLDWIDE",
                "statuses": []
            },
            {
                "id": "OUTSIDE_TEMPERATURE",
                "statuses": []
            },
            {
                "id": "SERVICE_PARTNER",
                "statuses": []
            },
            {
                "id": "MISUSE_PROTECTION",
                "statuses": []
            }
        ],
        "errors": [
            {
                "type": "UNAVAILABLE_SERVICE_PLATFORM_CAPABILITIES",
                "description": "Get capabilities call to VDBS failed because of response code is {429 TOO_MANY_REQUESTS} for user {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx} and vehicle {TMBJM0CKV1N12345}"
            }
        ]
    }
}
```