### PR TITLE
Add timestamps to models

### DIFF
--- a/fixtures/citigoe_iv_2020_ne132e2.yaml
+++ b/fixtures/citigoe_iv_2020_ne132e2.yaml
@@ -5,11 +5,13 @@ library_version: 0.15.4
 vehicles:
   - id: 0
     device_platform: MBB
+    timestamp: null
     system_model_id: NE13E2
     model: CitigoE iV
     model_year: '2020'
     trim_level: null
     software_version: null
+    timestamp: null
     capabilities:
       - id: AUTOMATION
         statuses: []
@@ -187,6 +189,7 @@ reports:
       renders: []
       device_platform: MBB
       workshop_mode_enabled: false
+      timestamp: null
       composite_renders:
         - layers:
             - url: >-
@@ -288,6 +291,7 @@ reports:
       "carCapturedTimestamp": "2024-12-17T07:53:01Z"}
     url: /v2/vehicle-status/TMOCKAA0AA000000
     result:
+      timestamp: null
       detail:
         bonnet: CLOSED
         sunroof: UNSUPPORTED
@@ -319,6 +323,7 @@ reports:
             https://mysmob.api.connect.skoda-auto.cz/api/v2/vehicle-status/render?carType=HATCHBACK&vehicleState=1-1-1-1-0-0-0-0-0&lastModifiedAt=1733938917&dimension=3x&theme=DARK
       car_captured_timestamp: '2024-12-17T07:53:01+00:00'
     error: null
+    timestamp: null
   - type: get
     vehicle_id: 0
     success: true
@@ -363,6 +368,7 @@ reports:
         unit_in_car: CELSIUS
       window_heating_enabled: null
       air_conditioning_without_external_power: true
+      timestamp: null
       outside_temperature:
         temperature_value: 8.5
         unit_in_car: CELSIUS
@@ -411,6 +417,7 @@ reports:
     url: /v1/maps/positions?vin=TMOCKAA0AA000000
     result:
       errors: []
+      timestamp: null
       positions:
         - address:
             country_code: DEU
@@ -437,6 +444,7 @@ reports:
       []}]}
     url: /v1/vehicle-health-report/warning-lights/TMOCKAA0AA000000
     result:
+      timestamp: null
       warning_lights:
         - category: ASSISTANCE
           defects: []
@@ -489,6 +497,7 @@ reports:
         target_state_of_charge_in_percent: null
       is_vehicle_in_saved_location: false
       car_captured_timestamp: '2024-12-17T04:56:43+00:00'
+      timestamp: null
       status:
         battery:
           state_of_charge_in_percent: 65
@@ -518,6 +527,7 @@ reports:
       "SATURDAY", "periodEnd": "SUNDAY", "openingTimes": []}]}}
     url: /v3/vehicle-maintenance/vehicles/TMOCKAA0AA000000
     result:
+      timestamp: null
       maintenance_report:
         captured_at: '2024-12-17T06:53:00+00:00'
         mileage_in_km: 25938
@@ -576,6 +586,7 @@ reports:
       secondary_engine_range: null
       total_range_in_km: 114
       ad_blue_range: null
+      timestamp: null
     error: null
   - type: get
     vehicle_id: 0
@@ -677,4 +688,5 @@ reports:
       overall_average_travel_time_in_min: 13
       overall_mileage_in_km: 12
       overall_travel_time_in_min: 26
+      timestamp: null
     error: null

--- a/fixtures/citigoe_iv_2020_ne132e2.yaml
+++ b/fixtures/citigoe_iv_2020_ne132e2.yaml
@@ -11,7 +11,6 @@ vehicles:
     model_year: '2020'
     trim_level: null
     software_version: null
-    timestamp: null
     capabilities:
       - id: AUTOMATION
         statuses: []

--- a/fixtures/citigoe_iv_2020_ne14e2_style.yaml
+++ b/fixtures/citigoe_iv_2020_ne14e2_style.yaml
@@ -5,6 +5,7 @@ library_version: 0.15.4
 vehicles:
   - id: 0
     device_platform: MBB
+    timestamp: null
     system_model_id: NE14E2
     model: CitigoE iV
     model_year: '2020'
@@ -193,6 +194,7 @@ reports:
       renders: []
       device_platform: MBB
       workshop_mode_enabled: false
+      timestamp: null
       composite_renders:
         - layers:
             - url: >-
@@ -294,6 +296,7 @@ reports:
       "carCapturedTimestamp": "2024-12-19T10:51:07Z"}
     url: /v2/vehicle-status/TMOCKAA0AA000000
     result:
+      timestamp: null
       detail:
         bonnet: CLOSED
         sunroof: UNSUPPORTED
@@ -369,6 +372,7 @@ reports:
         unit_in_car: CELSIUS
       window_heating_enabled: null
       air_conditioning_without_external_power: false
+      timestamp: null
       outside_temperature:
         temperature_value: 13.5
         unit_in_car: CELSIUS
@@ -417,6 +421,7 @@ reports:
     url: /v1/maps/positions?vin=TMOCKAA0AA000000
     result:
       errors: []
+      timestamp: null
       positions:
         - address:
             country_code: DEU
@@ -443,6 +448,7 @@ reports:
       []}]}
     url: /v1/vehicle-health-report/warning-lights/TMOCKAA0AA000000
     result:
+      timestamp: null
       warning_lights:
         - category: ASSISTANCE
           defects: []
@@ -494,6 +500,7 @@ reports:
         preferred_charge_mode: null
         target_state_of_charge_in_percent: null
       is_vehicle_in_saved_location: false
+      timestamp: null
       car_captured_timestamp: '2024-12-19T10:50:24+00:00'
       status:
         battery:
@@ -529,6 +536,7 @@ reports:
       "openingTimes": []}]}}
     url: /v3/vehicle-maintenance/vehicles/TMOCKAA0AA000000
     result:
+      timestamp: null
       maintenance_report:
         captured_at: '2024-12-19T11:26:05+00:00'
         mileage_in_km: 50137
@@ -601,6 +609,7 @@ reports:
       secondary_engine_range: null
       total_range_in_km: 137
       ad_blue_range: null
+      timestamp: null
     error: null
   - type: get
     vehicle_id: 0
@@ -627,6 +636,7 @@ reports:
       /v1/trip-statistics/TMOCKAA0AA000000?offsetType=week&offset=0&timezone=Europe%2FBerlin
     result:
       vehicle_type: ELECTRIC
+      timestamp: null
       detailed_statistics:
         - date: '2024-12-16'
           average_fuel_consumption: null
@@ -713,4 +723,5 @@ reports:
       overall_average_travel_time_in_min: 71
       overall_mileage_in_km: 186
       overall_travel_time_in_min: 283
+      timestamp: null
     error: null

--- a/fixtures/citigoe_iv_2021_ne14e2_best_of.yaml
+++ b/fixtures/citigoe_iv_2021_ne14e2_best_of.yaml
@@ -166,6 +166,7 @@ reports:
     service_partner:
       id: DEU11111
     software_version: null
+    timestamp: null
     specification:
       battery:
         capacity: 36
@@ -185,6 +186,7 @@ reports:
     state: ACTIVATED
     vin: TMOCKAA0AA000000
     workshop_mode_enabled: false
+    timestamp: null
   success: true
   type: get
   url: /v2/garage/vehicles/TMOCKAA0AA000000?connectivityGenerations=MOD1&connectivityGenerations=MOD2&connectivityGenerations=MOD3&connectivityGenerations=MOD4
@@ -204,6 +206,7 @@ reports:
     "carCapturedTimestamp": "2024-11-26T15:10:17Z"}'
   result:
     car_captured_timestamp: '2024-11-26T15:10:17+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -242,6 +245,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: true
+    timestamp: null
     car_captured_timestamp: '2024-11-26T07:17:32+00:00'
     charger_connection_state: DISCONNECTED
     charger_lock_state: LOCKED
@@ -297,6 +301,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -323,6 +328,7 @@ reports:
   result:
     captured_at: '2024-11-26T15:10:17+00:00'
     mileage_in_km: 38965
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -354,6 +360,7 @@ reports:
     available."}]}'
   result:
     car_captured_timestamp: '2024-11-26T13:33:53+00:00'
+    timestamp: null
     errors:
     - description: Care mode is not available.
       type: CARE_MODE_IS_NOT_AVAILABLE
@@ -399,6 +406,7 @@ reports:
     {"from": "13:10:00", "to": "16:00:00"}]}, {"periodStart": "SATURDAY", "periodEnd":
     "SUNDAY", "openingTimes": []}]}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-11-26T14:10:15+00:00'
       inspection_due_in_days: 681
@@ -464,6 +472,7 @@ reports:
       remaining_range_in_km: 88
     secondary_engine_range: null
     total_range_in_km: 88
+    timestamp: null
   success: true
   type: get
   url: /v2/vehicle-status/TMOCKAA0AA000000/driving-range
@@ -560,6 +569,7 @@ reports:
     overall_mileage_in_km: 26
     overall_travel_time_in_min: 25
     vehicle_type: ELECTRIC
+    timestamp: null
   success: true
   type: get
   url: /v1/trip-statistics/TMOCKAA0AA000000?offsetType=week&offset=0&timezone=Europe%2FBerlin
@@ -605,6 +615,7 @@ vehicles:
   - id: AIR_CONDITIONING
     statuses: []
   device_platform: MBB
+  timestamp: null
   id: 0
   model: CitigoE iV
   model_year: '2021'

--- a/fixtures/djapollo_enyaq_85_5AZJK2.yaml
+++ b/fixtures/djapollo_enyaq_85_5AZJK2.yaml
@@ -232,6 +232,7 @@ reports:
     service_partner:
       id: DEU11111
     software_version: '5.2'
+    timestamp: null
     specification:
       battery:
         capacity: 77
@@ -270,6 +271,7 @@ reports:
     "carCapturedTimestamp": "2025-01-04T08:55:40.569Z"}'
   result:
     car_captured_timestamp: '2025-01-04T08:55:40.569000+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -311,6 +313,7 @@ reports:
   result:
     air_conditioning_at_unlock: false
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: '2025-01-04T08:52:32+00:00'
     charger_connection_state: DISCONNECTED
     charger_lock_state: UNLOCKED
@@ -379,6 +382,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -405,6 +409,7 @@ reports:
   result:
     captured_at: '2025-01-04T08:47:50.688000+00:00'
     mileage_in_km: 5453
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -437,6 +442,7 @@ reports:
     car_captured_timestamp: '2025-01-04T08:52:34+00:00'
     errors: []
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: 'OFF'
       available_charge_modes:
@@ -476,6 +482,7 @@ reports:
     "SUNDAY", "openingTimes": []}]}, "predictiveMaintenance": {"setting": {"serviceActivated":
     true, "email": "user@example.com", "phone": "+49 1234 567890"}}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2025-01-04T08:55:40.703000+00:00'
       inspection_due_in_days: 642
@@ -547,6 +554,7 @@ reports:
       remaining_range_in_km: 310
     secondary_engine_range: null
     total_range_in_km: 310
+    timestamp: null
   success: true
   type: get
   url: /v2/vehicle-status/TMOCKAA0AA000000/driving-range
@@ -584,6 +592,7 @@ reports:
       fahrenheit: 68.0
       unit_in_car: CELSIUS
     timers: []
+    timestamp: null
   success: true
   type: get
   url: /v1/vehicle-automatization/TMOCKAA0AA000000/departure/timers?deviceDateTime=2025-01-04T12%3A24%3A53.420813%2B01%3A00
@@ -689,6 +698,7 @@ vehicles:
   - id: ROUTE_PLANNING_10_CHARGERS
     statuses: []
   device_platform: WCAR
+  timestamp: null
   id: 0
   model: Enyaq
   model_year: '2025'

--- a/fixtures/enyaq_2023_5AZJJ2_80.yaml
+++ b/fixtures/enyaq_2023_5AZJJ2_80.yaml
@@ -5,6 +5,7 @@ library_version: 0.16.0
 vehicles:
   - id: 0
     device_platform: WCAR
+    timestamp: null
     system_model_id: 5AZJJ2
     model: Enyaq
     model_year: '2023'
@@ -385,6 +386,7 @@ reports:
       service_partner:
         id: DEU11111
       software_version: '3.2'
+      timestamp: null
       license_plate: HH AA 1234
       errors: null
     error: null
@@ -415,6 +417,7 @@ reports:
       "carCapturedTimestamp": "2024-12-27T16:33:13.354Z"}
     url: /v2/vehicle-status/TMOCKAA0AA000000
     result:
+      timestamp: null
       detail:
         bonnet: CLOSED
         sunroof: UNSUPPORTED
@@ -499,6 +502,7 @@ reports:
         unit_in_car: CELSIUS
       window_heating_enabled: false
       air_conditioning_without_external_power: null
+      timestamp: null
       outside_temperature: null
     error: null
   - type: get
@@ -544,6 +548,7 @@ reports:
     url: /v1/maps/positions?vin=TMOCKAA0AA000000
     result:
       errors: []
+      timestamp: null
       positions:
         - address:
             country_code: DEU
@@ -572,6 +577,7 @@ reports:
       []}, {"category": "TIRE", "defects": []}]}
     url: /v1/vehicle-health-report/warning-lights/TMOCKAA0AA000000
     result:
+      timestamp: null
       warning_lights:
         - category: OTHER
           defects:
@@ -622,6 +628,7 @@ reports:
         preferred_charge_mode: MANUAL
         target_state_of_charge_in_percent: 100
       is_vehicle_in_saved_location: false
+      timestamp: null
       car_captured_timestamp: '2024-12-27T16:33:47+00:00'
       status:
         battery:
@@ -659,6 +666,7 @@ reports:
       "email": "user@example.com", "phone": "+49 1234 567890"}}}
     url: /v3/vehicle-maintenance/vehicles/TMOCKAA0AA000000
     result:
+      timestamp: null
       maintenance_report:
         captured_at: '2024-12-27T16:30:14.304000+00:00'
         mileage_in_km: 27640
@@ -736,6 +744,7 @@ reports:
       secondary_engine_range: null
       total_range_in_km: 247
       ad_blue_range: null
+      timestamp: null
     error: null
   - type: get
     vehicle_id: 0
@@ -785,4 +794,5 @@ reports:
         fahrenheit: 68
         unit_in_car: CELSIUS
       timers: []
+      timestamp: null
     error: null

--- a/fixtures/kamiq_2021_NW44KD_crossover.yaml
+++ b/fixtures/kamiq_2021_NW44KD_crossover.yaml
@@ -148,6 +148,7 @@ reports:
     state: ACTIVATED
     vin: TMOCKAA0AA000000
     workshop_mode_enabled: false
+    timestamp: null
   success: true
   type: get
   url: /v2/garage/vehicles/TMOCKAA0AA000000?connectivityGenerations=MOD1&connectivityGenerations=MOD2&connectivityGenerations=MOD3&connectivityGenerations=MOD4
@@ -167,6 +168,7 @@ reports:
     "carCapturedTimestamp": "2024-11-09T10:23:55Z"}'
   result:
     car_captured_timestamp: '2024-11-09T10:23:55+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -204,6 +206,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: null
     charger_connection_state: null
     charger_lock_state: null
@@ -240,6 +243,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -266,6 +270,7 @@ reports:
   result:
     captured_at: '2024-11-09T10:23:54+00:00'
     mileage_in_km: 77043
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -305,6 +310,7 @@ reports:
     - description: Charge limit is not available.
       type: CHARGE_LIMIT_IS_NOT_AVAILABLE
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: null
       available_charge_modes: []
@@ -356,6 +362,7 @@ reports:
     "", "messageId": "A224", "notificationId": 41508, "text": "Please add maximum
     n.a. of oil. You can continue driving."}]}]}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-11-09T10:23:54+00:00'
       inspection_due_in_days: 489
@@ -422,6 +429,7 @@ reports:
       remaining_range_in_km: 750
     secondary_engine_range: null
     total_range_in_km: 750
+    timestamp: null
   success: true
   type: get
   url: /v2/vehicle-status/TMOCKAA0AA000000/driving-range
@@ -544,6 +552,7 @@ reports:
     overall_mileage_in_km: 497
     overall_travel_time_in_min: 463
     vehicle_type: FUEL
+    timestamp: null
   success: true
   type: get
   url: /v1/trip-statistics/TMOCKAA0AA000000?offsetType=week&offset=0&timezone=Europe%2FBerlin
@@ -608,9 +617,11 @@ vehicles:
   - id: MISUSE_PROTECTION
     statuses: []
   device_platform: MBB_ODP
+  timestamp: null
   id: 0
   model: Kamiq
   model_year: '2021'
   software_version: null
   system_model_id: NW44KD
   trim_level: null
+  timestamp: null

--- a/fixtures/karoq_2022_nu74nv_se_l_expired_subscription.yaml
+++ b/fixtures/karoq_2022_nu74nv_se_l_expired_subscription.yaml
@@ -175,6 +175,7 @@ reports:
       view_point: main
     service_partner: null
     software_version: null
+    timestamp: null
     specification:
       battery: null
       body: SUV
@@ -211,6 +212,7 @@ reports:
     "threeX": "https://mysmob.api.connect.skoda-auto.cz/api/v2/vehicle-status/render?carType=SUV&vehicleState=9-9-9-9-0-0-3-3-0&lastModifiedAt=1729086727&dimension=3x&theme=DARK"}}}'
   result:
     car_captured_timestamp: null
+    timestamp: null
     detail:
       bonnet: UNKNOWN
       sunroof: UNSUPPORTED
@@ -248,6 +250,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: null
     charger_connection_state: null
     charger_lock_state: null
@@ -282,6 +285,7 @@ reports:
   result:
     errors: []
     positions: []
+    timestamp: null
   success: true
   type: get
   url: /v1/maps/positions?vin=TMOCKAA0AA000000
@@ -296,6 +300,7 @@ reports:
   result:
     captured_at: '2024-10-22T21:30:09+00:00'
     mileage_in_km: 21119
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -335,6 +340,7 @@ reports:
     - description: Charge limit is not available.
       type: CHARGE_LIMIT_IS_NOT_AVAILABLE
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: null
       available_charge_modes: []
@@ -353,6 +359,7 @@ reports:
   raw: '{"predictiveMaintenance": {"setting": {"serviceActivated": false, "email":
     "user@example.com", "phone": "+49 1234 567890"}}}'
   result:
+    timestamp: null
     maintenance_report: null
     predictive_maintenance:
       setting:
@@ -500,6 +507,7 @@ vehicles:
   - id: CARE_AND_INSURANCE
     statuses: []
   device_platform: MBB_ODP
+  timestamp: null
   id: 0
   model: Karoq
   model_year: '2022'

--- a/fixtures/karoq_2023_NU74MD_se_l.yaml
+++ b/fixtures/karoq_2023_NU74MD_se_l.yaml
@@ -135,6 +135,7 @@ reports:
     service_partner:
       id: DEU11111
     software_version: null
+    timestamp: null
     specification:
       battery: null
       body: SUV
@@ -172,6 +173,7 @@ reports:
     "carCapturedTimestamp": "2024-11-07T15:16:22Z"}'
   result:
     car_captured_timestamp: '2024-11-07T15:16:22+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -209,6 +211,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: null
     charger_connection_state: null
     charger_lock_state: null
@@ -245,6 +248,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -271,6 +275,7 @@ reports:
   result:
     captured_at: '2024-11-07T15:16:19+00:00'
     mileage_in_km: 10238
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -310,6 +315,7 @@ reports:
     - description: Charge limit is not available.
       type: CHARGE_LIMIT_IS_NOT_AVAILABLE
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: null
       available_charge_modes: []
@@ -340,6 +346,7 @@ reports:
     {"serviceActivated": true, "preferredChannel": "EMAIL", "email": "user@example.com",
     "phone": "+49 1234 567890"}}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-11-07T15:16:19+00:00'
       inspection_due_in_days: 642
@@ -408,6 +415,7 @@ reports:
       remaining_range_in_km: 209
     secondary_engine_range: null
     total_range_in_km: 209
+    timestamp: null
   success: true
   type: get
   url: /v2/vehicle-status/TMOCKAA0AA000000/driving-range
@@ -504,6 +512,7 @@ reports:
     overall_mileage_in_km: 57
     overall_travel_time_in_min: 95
     vehicle_type: FUEL
+    timestamp: null
   success: true
   type: get
   url: /v1/trip-statistics/TMOCKAA0AA000000?offsetType=week&offset=0&timezone=Europe%2FBerlin
@@ -570,6 +579,7 @@ vehicles:
   - id: CARE_AND_INSURANCE
     statuses: []
   device_platform: MBB_ODP
+  timestamp: null
   id: 0
   model: Karoq
   model_year: '2023'

--- a/fixtures/kodiaq_2023_NS74QZ_style.yaml
+++ b/fixtures/kodiaq_2023_NS74QZ_style.yaml
@@ -5,6 +5,7 @@ library_version: 0.13.4
 vehicles:
   - id: 0
     device_platform: MBB_ODP
+    timestamp: null
     system_model_id: NS74QZ
     model: Kodiaq
     model_year: "2023"
@@ -229,6 +230,7 @@ reports:
       service_partner:
         id: DEU11111
       software_version:
+      timestamp: null
       license_plate: HH AA 1234
       errors:
     error:
@@ -250,6 +252,7 @@ reports:
       "carCapturedTimestamp": "2024-12-02T16:46:09Z"}'
     url: "/v2/vehicle-status/TMOCKAA0AA000000"
     result:
+      timestamp: null
       detail:
         bonnet: CLOSED
         sunroof: UNSUPPORTED
@@ -314,6 +317,7 @@ reports:
       target_temperature:
       window_heating_enabled:
       air_conditioning_without_external_power:
+      timestamp: null
     error:
   - type: get
     vehicle_id: 0
@@ -353,6 +357,7 @@ reports:
     url: "/v1/maps/positions?vin=TMOCKAA0AA000000"
     result:
       errors: []
+      timestamp: null
       positions:
         - address:
             country_code: DEU
@@ -378,6 +383,7 @@ reports:
       {"category": "OTHER", "defects": []}]}'
     url: "/v1/vehicle-health-report/warning-lights/TMOCKAA0AA000000"
     result:
+      timestamp: null
       warning_lights:
         - category: ASSISTANCE
           defects: []
@@ -429,6 +435,7 @@ reports:
       is_vehicle_in_saved_location: false
       car_captured_timestamp:
       status:
+      timestamp: null
     error:
   - type: get
     vehicle_id: 0
@@ -446,6 +453,7 @@ reports:
       {"serviceActivated": true, "email": "user@example.com", "phone": "+49 1234 567890"}}}'
     url: "/v3/vehicle-maintenance/vehicles/TMOCKAA0AA000000"
     result:
+      timestamp: null
       maintenance_report:
         captured_at: "2024-12-02T16:46:08+00:00"
         mileage_in_km: 37711
@@ -499,7 +507,8 @@ reports:
         remaining_range_in_km: 70
       secondary_engine_range:
       total_range_in_km: 70
-      ad_blue_range:
+      ad_blue_range: null
+      timestamp: null
     error:
   - type: get
     vehicle_id: 0
@@ -516,6 +525,7 @@ reports:
     url: "/v1/trip-statistics/TMOCKAA0AA000000?offsetType=week&offset=0&timezone=Europe%2FBerlin"
     result:
       vehicle_type: FUEL
+      timestamp: null
       detailed_statistics:
         - date: "2024-12-02"
           average_fuel_consumption: 12.53
@@ -598,4 +608,5 @@ reports:
       overall_average_travel_time_in_min: 81
       overall_mileage_in_km: 26
       overall_travel_time_in_min: 81
+      timestamp: null
     error:

--- a/fixtures/kodiaq_2024_ps7d6z_exclusive.yaml
+++ b/fixtures/kodiaq_2024_ps7d6z_exclusive.yaml
@@ -199,6 +199,7 @@ reports:
     service_partner:
       id: DEU11111
     software_version: null
+    timestamp: null
     specification:
       battery: null
       body: SUV
@@ -236,6 +237,7 @@ reports:
     "carCapturedTimestamp": "2024-11-08T09:30:13Z"}'
   result:
     car_captured_timestamp: '2024-11-08T09:30:13+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: CLOSED
@@ -277,6 +279,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: '2024-11-04T16:43:12+00:00'
     charger_connection_state: null
     charger_lock_state: null
@@ -331,6 +334,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -357,6 +361,7 @@ reports:
   result:
     captured_at: '2024-11-08T09:30:02+00:00'
     mileage_in_km: 9647
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -396,6 +401,7 @@ reports:
     - description: Charge limit is not available.
       type: CHARGE_LIMIT_IS_NOT_AVAILABLE
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: null
       available_charge_modes: []
@@ -435,6 +441,7 @@ reports:
     "REJECTED", "type": "AUTO", "extras": [], "addOns": {}, "warnings": [{"iconName":
     "C_1_01", "messageId": "A21C", "notificationId": 41500, "text": "Fault: Wipers"}]}]}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-11-08T09:30:02+00:00'
       inspection_due_in_days: 576
@@ -496,6 +503,7 @@ reports:
       remaining_range_in_km: 650
     secondary_engine_range: null
     total_range_in_km: 650
+    timestamp: null
   success: true
   type: get
   url: /v2/vehicle-status/TMOCKAA0AA000000/driving-range
@@ -586,6 +594,7 @@ vehicles:
   - id: EXTENDED_CHARGING_SETTINGS
     statuses: []
   device_platform: MBB_ODP
+  timestamp: null
   id: 0
   model: Kodiaq
   model_year: '2024'

--- a/fixtures/kodiaq_iv_2024_ps7dyc_selection.yaml
+++ b/fixtures/kodiaq_iv_2024_ps7dyc_selection.yaml
@@ -5,6 +5,7 @@ library_version: 0.16.2
 vehicles:
   - id: 0
     device_platform: MBB_ODP
+    timestamp: null
     system_model_id: PS7DYC
     model: Kodiaq
     model_year: '2024'
@@ -321,6 +322,7 @@ reports:
       service_partner:
         id: DEU11111
       software_version: null
+      timestamp: null
       license_plate: HH AA 1234
       errors: null
     error: null
@@ -350,6 +352,7 @@ reports:
       "carCapturedTimestamp": "2025-01-12T08:14:22Z"}
     url: /v2/vehicle-status/TMOCKAA0AA000000
     result:
+      timestamp: null
       detail:
         bonnet: CLOSED
         sunroof: CLOSED
@@ -423,6 +426,7 @@ reports:
         unit_in_car: CELSIUS
       window_heating_enabled: false
       air_conditioning_without_external_power: true
+      timestamp: null
       outside_temperature: null
     error: null
   - type: get
@@ -468,6 +472,7 @@ reports:
     url: /v1/maps/positions?vin=TMOCKAA0AA000000
     result:
       errors: []
+      timestamp: null
       positions:
         - address:
             country_code: DEU
@@ -493,6 +498,7 @@ reports:
       "defects": []}, {"category": "OTHER", "defects": []}]}
     url: /v1/vehicle-health-report/warning-lights/TMOCKAA0AA000000
     result:
+      timestamp: null
       warning_lights:
         - category: ASSISTANCE
           defects: []
@@ -541,6 +547,7 @@ reports:
         preferred_charge_mode: MANUAL
         target_state_of_charge_in_percent: 100
       is_vehicle_in_saved_location: false
+      timestamp: null
       car_captured_timestamp: '2025-01-12T09:25:58+00:00'
       status:
         battery:
@@ -577,6 +584,7 @@ reports:
       "phone": "+49 1234 567890"}}}
     url: /v3/vehicle-maintenance/vehicles/TMOCKAA0AA000000
     result:
+      timestamp: null
       maintenance_report:
         captured_at: '2025-01-12T08:13:58+00:00'
         mileage_in_km: null
@@ -655,6 +663,7 @@ reports:
         remaining_range_in_km: 15
       total_range_in_km: 215
       ad_blue_range: null
+      timestamp: null
     error: null
   - type: get
     vehicle_id: 0
@@ -697,6 +706,7 @@ reports:
       /v1/trip-statistics/TMOCKAA0AA000000?offsetType=week&offset=0&timezone=Europe%2FBerlin
     result:
       vehicle_type: HYBRID
+      timestamp: null
       detailed_statistics:
         - date: '2025-01-06'
           average_fuel_consumption: 0
@@ -783,6 +793,7 @@ reports:
       overall_average_travel_time_in_min: 31
       overall_mileage_in_km: 246
       overall_travel_time_in_min: 218
+      timestamp: null
     error: null
   - type: get
     vehicle_id: 0
@@ -802,4 +813,5 @@ reports:
         fahrenheit: 72
         unit_in_car: CELSIUS
       timers: []
+      timestamp: null
     error: null

--- a/fixtures/octavia_2022.yaml
+++ b/fixtures/octavia_2022.yaml
@@ -175,6 +175,7 @@ reports:
         view_point: exterior_side
       view_type: PLUGGED_IN_DARK
     device_platform: MBB_ODP
+    timestamp: null
     errors: null
     license_plate: HH AA 1234
     name: Example Car
@@ -231,6 +232,7 @@ reports:
     "carCapturedTimestamp": "2024-11-19T12:19:43Z"}'
   result:
     car_captured_timestamp: '2024-11-19T12:19:43+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -272,6 +274,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: '2024-11-19T12:19:15+00:00'
     charger_connection_state: null
     charger_lock_state: null
@@ -336,6 +339,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -362,6 +366,7 @@ reports:
   result:
     captured_at: '2024-11-19T12:19:16+00:00'
     mileage_in_km: 52122
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -391,6 +396,7 @@ reports:
     "description": "Charge limit is not available."}]}'
   result:
     car_captured_timestamp: null
+    timestamp: null
     errors:
     - description: Care mode is not available.
       type: CARE_MODE_IS_NOT_AVAILABLE
@@ -439,6 +445,7 @@ reports:
     "mileageInKm": 36863, "resolution": "REJECTED", "type": "MANUAL", "extras": [{"notificationId":
     "OTHERS", "text": "Other"}], "addOns": {}, "warnings": []}]}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-11-19T12:19:16+00:00'
       inspection_due_in_days: 233
@@ -491,6 +498,7 @@ reports:
     520}, "carCapturedTimestamp": "2024-11-19T12:19:43Z"}'
   result:
     ad_blue_range: null
+    timestamp: null
     car_captured_timestamp: '2024-11-19T12:19:43+00:00'
     car_type: gasoline
     primary_engine_range:
@@ -597,6 +605,7 @@ reports:
     overall_average_travel_time_in_min: 2
     overall_mileage_in_km: 1
     overall_travel_time_in_min: 4
+    timestamp: null
     vehicle_type: FUEL
   success: true
   type: get
@@ -665,6 +674,7 @@ vehicles:
   - id: CARE_AND_INSURANCE
     statuses: []
   device_platform: MBB_ODP
+  timestamp: null
   id: 0
   model: Octavia
   model_year: '2022'

--- a/fixtures/octavia_2023_NX34JD_style.yaml
+++ b/fixtures/octavia_2023_NX34JD_style.yaml
@@ -196,6 +196,7 @@ reports:
     service_partner:
       id: DEU11111
     software_version: null
+    timestamp: null
     specification:
       battery: null
       body: Liftback
@@ -233,6 +234,7 @@ reports:
     "carCapturedTimestamp": "2024-11-13T14:06:23Z"}'
   result:
     car_captured_timestamp: '2024-11-13T14:06:23+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -275,6 +277,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: '2024-11-13T14:05:44+00:00'
     charger_connection_state: null
     charger_lock_state: null
@@ -345,6 +348,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -371,6 +375,7 @@ reports:
   result:
     captured_at: '2024-11-13T14:06:24+00:00'
     mileage_in_km: 10776
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -410,6 +415,7 @@ reports:
     - description: Charge limit is not available.
       type: CHARGE_LIMIT_IS_NOT_AVAILABLE
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: null
       available_charge_modes: []
@@ -438,6 +444,7 @@ reports:
     {"setting": {"serviceActivated": true, "preferredChannel": "EMAIL", "email": "user@example.com",
     "phone": "+49 1234 567890"}}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-11-13T14:06:24+00:00'
       inspection_due_in_days: 99
@@ -490,6 +497,7 @@ reports:
     590}, "carCapturedTimestamp": "2024-11-13T14:06:23Z"}'
   result:
     ad_blue_range: null
+    timestamp: null
     car_captured_timestamp: '2024-11-13T14:06:23+00:00'
     car_type: gasoline
     primary_engine_range:
@@ -600,6 +608,7 @@ reports:
     overall_average_travel_time_in_min: 27
     overall_mileage_in_km: 35
     overall_travel_time_in_min: 80
+    timestamp: null
     vehicle_type: FUEL
   success: true
   type: get
@@ -670,6 +679,7 @@ vehicles:
   - id: CARE_AND_INSURANCE
     statuses: []
   device_platform: MBB_ODP
+  timestamp: null
   id: 0
   model: Octavia
   model_year: '2023'

--- a/fixtures/octavia_2023_NX53L5_combi.yaml
+++ b/fixtures/octavia_2023_NX53L5_combi.yaml
@@ -167,6 +167,7 @@ reports:
         view_point: exterior_side
       view_type: PLUGGED_IN_DARK
     device_platform: MBB_ODP
+    timestamp: null
     errors: null
     license_plate: HH AA 1234
     name: Example Car
@@ -222,6 +223,7 @@ reports:
     "carCapturedTimestamp": "2024-11-06T11:38:26Z"}'
   result:
     car_captured_timestamp: '2024-11-06T11:38:26+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -264,6 +266,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: '2024-11-06T11:38:22+00:00'
     charger_connection_state: null
     charger_lock_state: null
@@ -334,6 +337,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -360,6 +364,7 @@ reports:
   result:
     captured_at: '2024-11-06T11:38:22+00:00'
     mileage_in_km: 47257
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -399,6 +404,7 @@ reports:
     - description: Charge limit is not available.
       type: CHARGE_LIMIT_IS_NOT_AVAILABLE
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: null
       available_charge_modes: []
@@ -419,6 +425,7 @@ reports:
     462, "oilServiceDueInKm": 13200}, "predictiveMaintenance": {"setting": {"serviceActivated":
     false, "email": "user@example.com", "phone": "+49 1234 567890"}}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-11-06T11:38:22+00:00'
       inspection_due_in_days: 462
@@ -444,6 +451,7 @@ reports:
     830}, "carCapturedTimestamp": "2024-11-06T11:38:26Z"}'
   result:
     ad_blue_range: null
+    timestamp: null
     car_captured_timestamp: '2024-11-06T11:38:26+00:00'
     car_type: gasoline
     primary_engine_range:
@@ -550,6 +558,7 @@ reports:
     overall_average_travel_time_in_min: 2
     overall_mileage_in_km: 2
     overall_travel_time_in_min: 7
+    timestamp: null
     vehicle_type: FUEL
   success: true
   type: get
@@ -612,6 +621,7 @@ vehicles:
   - id: MISUSE_PROTECTION
     statuses: []
   device_platform: MBB_ODP
+  timestamp: null
   id: 0
   model: Octavia
   model_year: '2023'

--- a/fixtures/octavia_2024_NX53L5_combi.yaml
+++ b/fixtures/octavia_2024_NX53L5_combi.yaml
@@ -184,6 +184,7 @@ reports:
     service_partner:
       id: DEU11111
     software_version: null
+    timestamp: null
     specification:
       battery: null
       body: Combi
@@ -221,6 +222,7 @@ reports:
     "carCapturedTimestamp": "2024-12-15T18:55:58Z"}'
   result:
     car_captured_timestamp: '2024-12-15T18:55:58+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -263,6 +265,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: '2024-12-15T18:55:48+00:00'
     charger_connection_state: null
     charger_lock_state: null
@@ -346,6 +349,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -372,6 +376,7 @@ reports:
   result:
     captured_at: '2024-12-15T18:55:58+00:00'
     mileage_in_km: 18309
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -411,6 +416,7 @@ reports:
     - description: Charge limit is not available.
       type: CHARGE_LIMIT_IS_NOT_AVAILABLE
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: null
       available_charge_modes: []
@@ -440,6 +446,7 @@ reports:
     []}]}, "predictiveMaintenance": {"setting": {"serviceActivated": true, "preferredChannel":
     "EMAIL", "email": "user@example.com", "phone": "+49 1234 567890"}}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-12-15T18:55:58+00:00'
       inspection_due_in_days: 444
@@ -497,6 +504,7 @@ reports:
     640}, "carCapturedTimestamp": "2024-12-15T18:55:58Z"}'
   result:
     ad_blue_range: null
+    timestamp: null
     car_captured_timestamp: '2024-12-15T18:55:58+00:00'
     car_type: gasoline
     primary_engine_range:
@@ -595,6 +603,7 @@ reports:
     overall_average_travel_time_in_min: null
     overall_mileage_in_km: null
     overall_travel_time_in_min: null
+    timestamp: null
     vehicle_type: FUEL
   success: true
   type: get
@@ -663,9 +672,11 @@ vehicles:
   - id: MISUSE_PROTECTION
     statuses: []
   device_platform: MBB_ODP
+  timestamp: null
   id: 0
   model: Octavia
   model_year: '2024'
   software_version: null
+  timestamp: null
   system_model_id: NX53L5
   trim_level: Business Edition

--- a/fixtures/octavia_iv_2021_nx56xc_combi_rs.yaml
+++ b/fixtures/octavia_iv_2021_nx56xc_combi_rs.yaml
@@ -5,6 +5,7 @@ library_version: 0.13.2
 vehicles:
   - id: 0
     device_platform: MBB_ODP
+    timestamp: null
     system_model_id: NX56XC
     model: Octavia
     model_year: '2021'
@@ -361,6 +362,7 @@ reports:
       service_partner:
         id: DEU11111
       software_version: null
+      timestamp: null
       license_plate: HH AA 1234
       errors: null
     error: null
@@ -390,6 +392,7 @@ reports:
       "carCapturedTimestamp": "2024-11-29T06:57:10Z"}
     url: /v2/vehicle-status/TMOCKAA0AA000000
     result:
+      timestamp: null
       detail:
         bonnet: CLOSED
         sunroof: CLOSED
@@ -463,6 +466,7 @@ reports:
         unit_in_car: CELSIUS
       window_heating_enabled: null
       air_conditioning_without_external_power: true
+      timestamp: null
       outside_temperature: null
     error: null
   - type: get
@@ -485,6 +489,7 @@ reports:
     url: /v1/maps/positions?vin=TMOCKAA0AA000000
     result:
       errors: []
+      timestamp: null
       positions:
         - address:
             country_code: DEU
@@ -511,6 +516,7 @@ reports:
       []}]}
     url: /v1/vehicle-health-report/warning-lights/TMOCKAA0AA000000
     result:
+      timestamp: null
       warning_lights:
         - category: ASSISTANCE
           defects: []
@@ -561,6 +567,7 @@ reports:
         preferred_charge_mode: null
         target_state_of_charge_in_percent: null
       is_vehicle_in_saved_location: false
+      timestamp: null
       car_captured_timestamp: '2024-11-29T06:55:43+00:00'
       status:
         battery:
@@ -592,6 +599,7 @@ reports:
       567890"}}}
     url: /v3/vehicle-maintenance/vehicles/TMOCKAA0AA000000
     result:
+      timestamp: null
       maintenance_report:
         captured_at: '2024-11-29T06:57:10+00:00'
         mileage_in_km: 54263
@@ -653,6 +661,7 @@ reports:
         remaining_range_in_km: 31
       total_range_in_km: 291
       ad_blue_range: null
+      timestamp: null
     error: null
   - type: get
     vehicle_id: 0
@@ -759,4 +768,5 @@ reports:
       overall_average_travel_time_in_min: 16
       overall_mileage_in_km: 56
       overall_travel_time_in_min: 82
+      timestamp: null
     error: null

--- a/fixtures/octavia_iv_2022_nx34vc_liftback_style.yaml
+++ b/fixtures/octavia_iv_2022_nx34vc_liftback_style.yaml
@@ -5,6 +5,7 @@ library_version: 0.13.4
 vehicles:
   - id: 0
     device_platform: MBB_ODP
+    timestamp: null
     system_model_id: NX34VC
     model: Octavia
     model_year: '2022'
@@ -351,6 +352,7 @@ reports:
       service_partner:
         id: DEU11111
       software_version: null
+      timestamp: null
       license_plate: HH AA 1234
       errors: null
     error: null
@@ -380,6 +382,7 @@ reports:
       "carCapturedTimestamp": "2024-12-05T18:27:30Z"}
     url: /v2/vehicle-status/TMOCKAA0AA000000
     result:
+      timestamp: null
       detail:
         bonnet: CLOSED
         sunroof: UNSUPPORTED
@@ -455,6 +458,7 @@ reports:
         unit_in_car: CELSIUS
       window_heating_enabled: null
       air_conditioning_without_external_power: true
+      timestamp: null
       outside_temperature:
         temperature_value: 5.0
         unit_in_car: CELSIUS
@@ -503,6 +507,7 @@ reports:
     url: /v1/maps/positions?vin=TMOCKAA0AA000000
     result:
       errors: []
+      timestamp: null
       positions:
         - address:
             country_code: DEU
@@ -529,6 +534,7 @@ reports:
       []}]}
     url: /v1/vehicle-health-report/warning-lights/TMOCKAA0AA000000
     result:
+      timestamp: null
       warning_lights:
         - category: ASSISTANCE
           defects: []
@@ -580,6 +586,7 @@ reports:
         preferred_charge_mode: null
         target_state_of_charge_in_percent: null
       is_vehicle_in_saved_location: false
+      timestamp: null
       car_captured_timestamp: '2024-12-05T19:32:44+00:00'
       status:
         battery:
@@ -646,6 +653,7 @@ reports:
       41568)"}]}]}}
     url: /v3/vehicle-maintenance/vehicles/TMOCKAA0AA000000
     result:
+      timestamp: null
       maintenance_report:
         captured_at: '2024-12-05T18:27:20+00:00'
         mileage_in_km: 45073
@@ -720,6 +728,7 @@ reports:
         remaining_range_in_km: 0
       total_range_in_km: 700
       ad_blue_range: null
+      timestamp: null
     error: null
   - type: get
     vehicle_id: 0
@@ -829,4 +838,5 @@ reports:
       overall_average_travel_time_in_min: 45
       overall_mileage_in_km: 117
       overall_travel_time_in_min: 181
+      timestamp: null
     error: null

--- a/fixtures/prior99_enyaq_2024_5AZFF2_idle_full_battery.yaml
+++ b/fixtures/prior99_enyaq_2024_5AZFF2_idle_full_battery.yaml
@@ -230,6 +230,7 @@ reports:
     service_partner:
       id: DEU11111
     software_version: '3.7'
+    timestamp: null
     specification:
       battery:
         capacity: 58
@@ -268,6 +269,7 @@ reports:
     "carCapturedTimestamp": "2024-10-14T23:11:45.725Z"}'
   result:
     car_captured_timestamp: '2024-10-14T23:11:45.725000+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -308,6 +310,7 @@ reports:
   result:
     air_conditioning_at_unlock: true
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: '2024-10-14T23:11:50+00:00'
     charger_connection_state: DISCONNECTED
     charger_lock_state: UNLOCKED
@@ -353,6 +356,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -379,6 +383,7 @@ reports:
   result:
     captured_at: '2024-10-14T16:08:00.382000+00:00'
     mileage_in_km: 9092
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -411,6 +416,7 @@ reports:
     car_captured_timestamp: '2024-10-14T23:11:50+00:00'
     errors: []
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: 'OFF'
       available_charge_modes:
@@ -449,6 +455,7 @@ reports:
     []}]}, "predictiveMaintenance": {"setting": {"serviceActivated": true, "preferredChannel":
     "EMAIL", "email": "user@example.com", "phone": "+49 1234 567890"}}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-10-14T23:11:45.933000+00:00'
       inspection_due_in_days: 591
@@ -506,6 +513,7 @@ reports:
     "2024-10-14T16:15:14Z"}'
   result:
     ad_blue_range: null
+    timestamp: null
     car_captured_timestamp: '2024-10-14T16:15:14+00:00'
     car_type: electric
     primary_engine_range:
@@ -630,6 +638,7 @@ vehicles:
   - id: VEHICLE_WAKE_UP_TRIGGER
     statuses: []
   device_platform: WCAR
+  timestamp: null
   id: 0
   model: Enyaq
   model_year: '2024'

--- a/fixtures/prior99_octavia_2018_5E535D_ambition.yaml
+++ b/fixtures/prior99_octavia_2018_5E535D_ambition.yaml
@@ -90,6 +90,7 @@ reports:
       errors: null 
     composite_renders: []
     device_platform: MBB
+    timestamp: null
     errors:
     - description: Getting render of view point {exterior_side} for vehicle VIN {TMOCKAA0AA000000}
         failed with message {404 Not Found from GET http://render-service/api/v1/renders/TMOCKAA0AA000000}
@@ -144,6 +145,7 @@ reports:
     "carCapturedTimestamp": "2024-10-16T17:46:58Z"}'
   result:
     car_captured_timestamp: '2024-10-16T17:46:58+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -181,6 +183,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: null
     charger_connection_state: null
     charger_lock_state: null
@@ -217,6 +220,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -242,6 +246,7 @@ reports:
   result:
     captured_at: null
     mileage_in_km: null
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -281,6 +286,7 @@ reports:
     - description: Charge limit is not available.
       type: CHARGE_LIMIT_IS_NOT_AVAILABLE
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: null
       available_charge_modes: []
@@ -310,6 +316,7 @@ reports:
     []}]}, "predictiveMaintenance": {"setting": {"serviceActivated": true, "preferredChannel":
     "EMAIL", "email": "user@example.com", "phone": "+49 1234 567890"}}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-10-16T17:46:55+00:00'
       inspection_due_in_days: 137
@@ -367,6 +374,7 @@ reports:
     530}, "carCapturedTimestamp": "2024-10-16T17:46:58Z"}'
   result:
     ad_blue_range: null
+    timestamp: null
     car_captured_timestamp: '2024-10-16T17:46:58+00:00'
     car_type: diesel
     primary_engine_range:
@@ -475,6 +483,7 @@ reports:
     overall_average_travel_time_in_min: 25
     overall_mileage_in_km: 80
     overall_travel_time_in_min: 75
+    timestamp: null
     vehicle_type: FUEL
   success: true
   type: get
@@ -535,6 +544,7 @@ vehicles:
   - id: VEHICLE_HEALTH_WARNINGS_WITH_WAKE_UP
     statuses: []
   device_platform: MBB
+  timestamp: null
   id: 0
   model: Octavia
   model_year: '2018'

--- a/fixtures/sonar98_enyaq_2022_5AZJJ2.yaml
+++ b/fixtures/sonar98_enyaq_2022_5AZJJ2.yaml
@@ -230,6 +230,7 @@ reports:
       view_point: main
     service_partner:
       id: DEU11111
+    timestamp: null
     software_version: '3.0'
     specification:
       battery:
@@ -269,6 +270,7 @@ reports:
     "carCapturedTimestamp": "2024-12-04T13:31:07.28Z"}'
   result:
     car_captured_timestamp: '2024-12-04T13:31:07.280000+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -309,6 +311,7 @@ reports:
   result:
     air_conditioning_at_unlock: false
     air_conditioning_without_external_power: null
+    timestamp: null
     car_captured_timestamp: '2024-12-04T13:31:12+00:00'
     charger_connection_state: CONNECTED
     charger_lock_state: LOCKED
@@ -376,6 +379,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -402,6 +406,7 @@ reports:
   result:
     captured_at: '2024-12-04T13:31:33.083000+00:00'
     mileage_in_km: 44028
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -434,6 +439,7 @@ reports:
     car_captured_timestamp: '2024-12-04T13:32:15+00:00'
     errors: []
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: 'OFF'
       available_charge_modes:
@@ -469,6 +475,7 @@ reports:
     "FRIDAY", "openingTimes": [{"from": "08:00:00", "to": "17:00:00"}]}, {"periodStart":
     "SATURDAY", "periodEnd": "SUNDAY", "openingTimes": []}]}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-12-04T13:31:07.296000+00:00'
       inspection_due_in_days: -26
@@ -516,6 +523,7 @@ reports:
     "2024-12-04T13:32:15Z"}'
   result:
     ad_blue_range: null
+    timestamp: null
     car_captured_timestamp: '2024-12-04T13:32:15+00:00'
     car_type: electric
     primary_engine_range:
@@ -642,6 +650,7 @@ vehicles:
   - id: VEHICLE_WAKE_UP_TRIGGER
     statuses: []
   device_platform: WCAR
+  timestamp: null
   id: 0
   model: Enyaq
   model_year: '2022'

--- a/fixtures/superb_2024_3v35wz_liftback_l_and_k.yaml
+++ b/fixtures/superb_2024_3v35wz_liftback_l_and_k.yaml
@@ -5,11 +5,13 @@ library_version: 0.13.0
 vehicles:
   - id: 0
     device_platform: MBB_ODP
+    timestamp: null
     system_model_id: 3V35WZ
     model: Superb
     model_year: '2024'
     trim_level: L&K
     software_version: null
+    timestamp: null
     capabilities:
       - id: ACCESS
         statuses: []
@@ -352,6 +354,7 @@ reports:
       service_partner:
         id: DEU11111
       software_version: null
+      timestamp: null
       license_plate: null
       errors: null
     error: null
@@ -381,6 +384,7 @@ reports:
       "carCapturedTimestamp": "2024-11-27T07:07:33Z"}
     url: /v2/vehicle-status/TMOCKAA0AA000000
     result:
+      timestamp: null
       detail:
         bonnet: CLOSED
         sunroof: CLOSED
@@ -473,6 +477,7 @@ reports:
       target_temperature: null
       window_heating_enabled: null
       air_conditioning_without_external_power: null
+      timestamp: null
       outside_temperature: null
     error: null
   - type: get
@@ -512,6 +517,7 @@ reports:
       state: 'OFF'
       start_mode: HEATING
       duration_in_seconds: 1800
+      timestamp: null
       target_temperature: null
       car_captured_timestamp: '2024-11-27T07:06:35+00:00'
       estimated_date_time_to_reach_target_temperature: null
@@ -532,6 +538,7 @@ reports:
     url: /v1/maps/positions?vin=TMOCKAA0AA000000
     result:
       errors: []
+      timestamp: null
       positions:
         - address:
             country_code: DEU
@@ -558,6 +565,7 @@ reports:
       []}]}
     url: /v1/vehicle-health-report/warning-lights/TMOCKAA0AA000000
     result:
+      timestamp: null
       warning_lights:
         - category: ASSISTANCE
           defects: []
@@ -608,6 +616,7 @@ reports:
         preferred_charge_mode: null
         target_state_of_charge_in_percent: null
       is_vehicle_in_saved_location: false
+      timestamp: null
       car_captured_timestamp: null
       status: null
     error: null
@@ -634,6 +643,7 @@ reports:
       "user@example.com", "phone": "+49 1234 567890"}}}
     url: /v3/vehicle-maintenance/vehicles/TMOCKAA0AA000000
     result:
+      timestamp: null
       maintenance_report:
         captured_at: '2024-11-27T07:07:32+00:00'
         mileage_in_km: 26199
@@ -702,6 +712,7 @@ reports:
       secondary_engine_range: null
       total_range_in_km: 590
       ad_blue_range: null
+      timestamp: null
     error: null
   - type: get
     vehicle_id: 0
@@ -812,4 +823,5 @@ reports:
       overall_average_travel_time_in_min: 50
       overall_mileage_in_km: 49
       overall_travel_time_in_min: 149
+      timestamp: null
     error: null

--- a/fixtures/superb_iv_2020_3v35xc_liftback_l_and_k.yaml
+++ b/fixtures/superb_iv_2020_3v35xc_liftback_l_and_k.yaml
@@ -216,6 +216,7 @@ reports:
     service_partner:
       id: DEU11111
     software_version: null
+    timestamp: null
     specification:
       battery:
         capacity: 13
@@ -254,6 +255,7 @@ reports:
     "carCapturedTimestamp": "2024-10-16T17:40:53Z"}'
   result:
     car_captured_timestamp: '2024-10-16T17:40:53+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: CLOSED
@@ -292,6 +294,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: false
+    timestamp: null
     car_captured_timestamp: '2024-10-16T17:39:43+00:00'
     charger_connection_state: DISCONNECTED
     charger_lock_state: UNLOCKED
@@ -327,6 +330,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -353,6 +357,7 @@ reports:
   result:
     captured_at: '2024-10-16T17:40:52+00:00'
     mileage_in_km: 46949
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -391,6 +396,7 @@ reports:
     - description: Charge limit is not available.
       type: CHARGE_LIMIT_IS_NOT_AVAILABLE
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: null
       available_charge_modes: []
@@ -450,6 +456,7 @@ reports:
     [{"iconName": "H_2_19", "messageId": "A2CB", "notificationId": 41675, "text":
     "Error: Emergency call function. Please service vehicle."}]}]}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-10-16T17:40:52+00:00'
       inspection_due_in_days: 265
@@ -503,6 +510,7 @@ reports:
     63, "remainingRangeInKm": 23}, "carCapturedTimestamp": "2024-10-16T17:40:53Z"}'
   result:
     ad_blue_range: null
+    timestamp: null
     car_captured_timestamp: '2024-10-16T17:40:53+00:00'
     car_type: hybrid
     primary_engine_range:
@@ -618,6 +626,7 @@ reports:
     overall_average_travel_time_in_min: 24
     overall_mileage_in_km: 41
     overall_travel_time_in_min: 73
+    timestamp: null
     vehicle_type: HYBRID
   success: true
   type: get
@@ -693,9 +702,11 @@ vehicles:
   - id: AIR_CONDITIONING
     statuses: []
   device_platform: MBB_ODP
+  timestamp: null
   id: 0
   model: Superb
   model_year: '2020'
   software_version: null
+  timestamp: null
   system_model_id: 3V35XC
   trim_level: L&K iV

--- a/fixtures/superb_iv_2021_3v54xc.yaml
+++ b/fixtures/superb_iv_2021_3v54xc.yaml
@@ -225,6 +225,7 @@ reports:
     service_partner:
       id: DEU11111
     software_version: null
+    timestamp: null
     specification:
       battery:
         capacity: 13
@@ -263,6 +264,7 @@ reports:
     "carCapturedTimestamp": "2024-11-11T05:44:40Z"}'
   result:
     car_captured_timestamp: '2024-11-11T05:44:40+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -301,6 +303,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: true
+    timestamp: null
     car_captured_timestamp: '2024-11-09T18:06:32+00:00'
     charger_connection_state: DISCONNECTED
     charger_lock_state: UNLOCKED
@@ -336,6 +339,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -362,6 +366,7 @@ reports:
   result:
     captured_at: '2024-11-11T05:44:37+00:00'
     mileage_in_km: 104348
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -400,6 +405,7 @@ reports:
     - description: Charge limit is not available.
       type: CHARGE_LIMIT_IS_NOT_AVAILABLE
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: null
       available_charge_modes: []
@@ -437,6 +443,7 @@ reports:
     {"setting": {"serviceActivated": true, "email": "user@example.com", "phone": "+49
     1234 567890"}}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-11-11T05:44:37+00:00'
       inspection_due_in_days: 524
@@ -488,6 +495,7 @@ reports:
     20, "currentFuelLevelInPercent": 20}, "carCapturedTimestamp": "2024-11-11T05:44:40Z"}'
   result:
     ad_blue_range: null
+    timestamp: null
     car_captured_timestamp: '2024-11-11T05:44:40+00:00'
     car_type: gasoline
     primary_engine_range:
@@ -586,6 +594,7 @@ reports:
     overall_average_travel_time_in_min: null
     overall_mileage_in_km: null
     overall_travel_time_in_min: null
+    timestamp: null
     vehicle_type: HYBRID
   success: true
   type: get
@@ -667,6 +676,7 @@ vehicles:
   - id: AIR_CONDITIONING
     statuses: []
   device_platform: MBB_ODP
+  timestamp: null
   id: 0
   model: Superb
   model_year: '2021'

--- a/fixtures/superb_iv_combi_2022_3V53XC_standing_still.yaml
+++ b/fixtures/superb_iv_combi_2022_3V53XC_standing_still.yaml
@@ -224,6 +224,7 @@ reports:
     service_partner:
       id: DEU11111
     software_version: null
+    timestamp: null
     specification:
       battery: null
       body: Combi
@@ -261,6 +262,7 @@ reports:
     "carCapturedTimestamp": "2024-11-09T19:24:01Z"}'
   result:
     car_captured_timestamp: '2024-11-09T19:24:01+00:00'
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: UNSUPPORTED
@@ -299,6 +301,7 @@ reports:
   result:
     air_conditioning_at_unlock: null
     air_conditioning_without_external_power: true
+    timestamp: null
     car_captured_timestamp: '2024-10-30T16:37:12+00:00'
     charger_connection_state: DISCONNECTED
     charger_lock_state: UNLOCKED
@@ -334,6 +337,7 @@ reports:
     []}'
   result:
     errors: []
+    timestamp: null
     positions:
     - address:
         city: Example City
@@ -360,6 +364,7 @@ reports:
   result:
     captured_at: '2024-11-09T19:23:59+00:00'
     mileage_in_km: null
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -398,6 +403,7 @@ reports:
     - description: Charge limit is not available.
       type: CHARGE_LIMIT_IS_NOT_AVAILABLE
     is_vehicle_in_saved_location: false
+    timestamp: null
     settings:
       auto_unlock_plug_when_charged: null
       available_charge_modes: []
@@ -434,6 +440,7 @@ reports:
     "SUNDAY", "openingTimes": []}]}, "predictiveMaintenance": {"setting": {"serviceActivated":
     true, "email": "user@example.com", "phone": "+49 1234 567890"}}}'
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2024-11-09T19:23:59+00:00'
       inspection_due_in_days: 677
@@ -486,6 +493,7 @@ reports:
     "electric", "currentSoCInPercent": 20}, "carCapturedTimestamp": "2024-11-09T19:24:01Z"}'
   result:
     ad_blue_range: null
+    timestamp: null
     car_captured_timestamp: '2024-11-09T19:24:01+00:00'
     car_type: hybrid
     primary_engine_range:
@@ -588,6 +596,7 @@ reports:
     overall_average_travel_time_in_min: null
     overall_mileage_in_km: null
     overall_travel_time_in_min: null
+    timestamp: null
     vehicle_type: HYBRID
   success: true
   type: get
@@ -669,6 +678,7 @@ vehicles:
   - id: AIR_CONDITIONING
     statuses: []
   device_platform: MBB_ODP
+  timestamp: null
   id: 0
   model: Superb
   model_year: '2022'

--- a/fixtures/webspider_enyaq_2021_5AZJJ2.yaml
+++ b/fixtures/webspider_enyaq_2021_5AZJJ2.yaml
@@ -290,6 +290,7 @@ reports:
       errors: null 
     renders: []
     device_platform: WCAR
+    timestamp: null
     workshop_mode_enabled: false
     composite_renders:
     - layers:
@@ -371,6 +372,7 @@ reports:
     "carCapturedTimestamp": "2025-01-05T22:51:46.49Z"}'
   url: "/v2/vehicle-status/TMOCKAA0AA000000"
   result:
+    timestamp: null
     detail:
       bonnet: CLOSED
       sunroof: CLOSED
@@ -448,6 +450,7 @@ reports:
       unit_in_car: CELSIUS
     window_heating_enabled: true
     air_conditioning_without_external_power: 
+    timestamp: null
     outside_temperature: 
   error: 
 - type: get
@@ -489,6 +492,7 @@ reports:
     []}'
   url: "/v1/maps/positions?vin=TMOCKAA0AA000000"
   result:
+    timestamp: null
     errors: []
     positions:
     - address:
@@ -514,6 +518,7 @@ reports:
     []}, {"category": "OTHER", "defects": []}]}'
   url: "/v1/vehicle-health-report/warning-lights/TMOCKAA0AA000000"
   result:
+    timestamp: null
     warning_lights:
     - category: ASSISTANCE
       defects: []
@@ -556,6 +561,7 @@ reports:
       preferred_charge_mode: MANUAL
       target_state_of_charge_in_percent: 80
     is_vehicle_in_saved_location: false
+    timestamp: null
     car_captured_timestamp: '2025-01-05T22:52:08+00:00'
     status:
       battery:
@@ -586,6 +592,7 @@ reports:
     "user@example.com", "phone": "+49 1234 567890"}}}'
   url: "/v3/vehicle-maintenance/vehicles/TMOCKAA0AA000000"
   result:
+    timestamp: null
     maintenance_report:
       captured_at: '2025-01-05T22:51:46.580000+00:00'
       mileage_in_km: 87776
@@ -652,6 +659,7 @@ reports:
     secondary_engine_range: 
     total_range_in_km: 136
     ad_blue_range: 
+    timestamp: null
   error: 
 - type: get
   vehicle_id: 0
@@ -690,6 +698,7 @@ reports:
     "timers": []}'
   url: "/v1/vehicle-automatization/TMOCKAA0AA000000/departure/timers?deviceDateTime=2025-01-05T23%3A58%3A39.916266%2B01%3A00"
   result:
+    timestamp: null
     car_captured_timestamp: 
     first_occurring_timer_id: 
     minimum_battery_state_of_charge_in_percent: 

--- a/myskoda/models/air_conditioning.py
+++ b/myskoda/models/air_conditioning.py
@@ -190,3 +190,4 @@ class AirConditioning(DataClassORJSONMixin):
     outside_temperature: OutsideTemperature | None = field(
         default=None, metadata=field_options(alias="outsideTemperature")
     )
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/auxiliary_heating.py
+++ b/myskoda/models/auxiliary_heating.py
@@ -96,3 +96,4 @@ class AuxiliaryHeating(DataClassORJSONMixin):
     outside_temperature: OutsideTemperature | None = field(
         default=None, metadata=field_options(alias="outsideTemperature")
     )
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/charging.py
+++ b/myskoda/models/charging.py
@@ -129,3 +129,4 @@ class Charging(DataClassORJSONMixin):
         default=None, metadata=field_options(alias="carCapturedTimestamp")
     )
     status: ChargingStatus | None = field(default=None)
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/departure.py
+++ b/myskoda/models/departure.py
@@ -107,3 +107,4 @@ class DepartureInfo(DataClassORJSONMixin):
     timers: list[DepartureTimer] | None = field(
         default=None, metadata=field_options(alias="timers")
     )
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/driving_range.py
+++ b/myskoda/models/driving_range.py
@@ -42,3 +42,4 @@ class DrivingRange(DataClassORJSONMixin):
         default=None, metadata=field_options(alias="totalRangeInKm")
     )
     ad_blue_range: int | None = field(default=None, metadata=field_options(alias="adBlueRange"))
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/garage.py
+++ b/myskoda/models/garage.py
@@ -2,6 +2,7 @@
 
 import logging
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 
 from mashumaro import field_options
@@ -51,3 +52,4 @@ class Garage(DataClassORJSONMixin):
 
     vehicles: list[GarageEntry] | None = field(default=None)
     errors: list[GarageError] | None = field(default=None)
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/health.py
+++ b/myskoda/models/health.py
@@ -39,3 +39,4 @@ class Health(DataClassORJSONMixin):
     warning_lights: list[WarningLight] = field(metadata=field_options(alias="warningLights"))
     mileage_in_km: int | None = field(default=None, metadata=field_options(alias="mileageInKm"))
     captured_at: datetime | None = field(default=None, metadata=field_options(alias="capturedAt"))
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/info.py
+++ b/myskoda/models/info.py
@@ -2,7 +2,7 @@
 
 import logging
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime
 from enum import StrEnum
 
 from mashumaro import field_options
@@ -285,6 +285,7 @@ class Info(DataClassORJSONMixin):
     )
     license_plate: str | None = field(default=None, metadata=field_options(alias="licensePlate"))
     errors: list[Error] | None = field(default=None)
+    timestamp: datetime | None = field(default=None)
 
     def has_capability(self, cap: CapabilityId) -> bool:
         """Check for a capability.

--- a/myskoda/models/maintenance.py
+++ b/myskoda/models/maintenance.py
@@ -92,3 +92,4 @@ class Maintenance(DataClassORJSONMixin):
     preferred_service_partner: ServicePartner | None = field(
         default=None, metadata=field_options(alias="preferredServicePartner")
     )
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/operation_request.py
+++ b/myskoda/models/operation_request.py
@@ -1,6 +1,7 @@
 """Models for operation requests, returned by the MQTT broker."""
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 
 from mashumaro import field_options
@@ -59,3 +60,4 @@ class OperationRequest(DataClassORJSONMixin):
     operation: OperationName
     status: OperationStatus
     error_code: str | None = field(default=None, metadata=field_options(alias="errorCode"))
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/position.py
+++ b/myskoda/models/position.py
@@ -1,6 +1,7 @@
 """Models for responses of api/v2/vehicle-status/{vin}/driving-range."""
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 
 from mashumaro import field_options
@@ -37,3 +38,4 @@ class Positions(DataClassORJSONMixin):
 
     errors: list[Error]
     positions: list[Position]
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/spin.py
+++ b/myskoda/models/spin.py
@@ -1,6 +1,7 @@
 """Models for responses of api/v1/spin/verify."""
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 
 from mashumaro import field_options
@@ -29,3 +30,4 @@ class Spin(DataClassORJSONMixin):
         metadata=field_options(alias="verificationStatus")
     )
     spin_status: SpinStatus | None = field(default=None, metadata=field_options(alias="spinStatus"))
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/status.py
+++ b/myskoda/models/status.py
@@ -74,6 +74,7 @@ class Status(DataClassORJSONMixin):
     car_captured_timestamp: datetime | None = field(
         default=None, metadata=field_options(alias="carCapturedTimestamp")
     )
+    timestamp: datetime | None = field(default=None)
 
     def _extract_window_door_state_list_from_url(self) -> list[int]:
         """Extract window/door states from renders url.

--- a/myskoda/models/trip_statistics.py
+++ b/myskoda/models/trip_statistics.py
@@ -1,7 +1,7 @@
 """Models for responses of api/v2/vehicle-status/{vin}."""
 
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime
 from enum import StrEnum
 
 from mashumaro import field_options
@@ -73,3 +73,4 @@ class TripStatistics(DataClassORJSONMixin):
     overall_travel_time_in_min: int | None = field(
         default=None, metadata=field_options(alias="overallTravelTimeInMin")
     )
+    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/user.py
+++ b/myskoda/models/user.py
@@ -1,7 +1,7 @@
 """User that is using the API."""
 
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime
 from enum import StrEnum
 
 from mashumaro import field_options
@@ -42,3 +42,4 @@ class User(DataClassORJSONMixin):
     )
     phone: str | None = None
     country: str | None = None
+    timestamp: datetime | None = field(default=None)


### PR DESCRIPTION
This adds an optional `timestamp` field to models that do not have it yet.

Per-model timestamps are useful in case we want to start caching certain API responses, for instance because the do not change very often.