### PR TITLE
Add support for mqtt departure-error-plug message

### DIFF
--- a/myskoda/models/charging.py
+++ b/myskoda/models/charging.py
@@ -60,10 +60,6 @@ class PlugUnlockMode(StrEnum):
     OFF = "OFF"
 
 
-class ServiceEventChargingError(StrEnum):
-    STOPPED_DEVICE = "STOPPED_DEVICE"
-
-
 @dataclass
 class Settings(DataClassORJSONMixin):
     available_charge_modes: list[ChargeMode] = field(

--- a/myskoda/models/service_event.py
+++ b/myskoda/models/service_event.py
@@ -8,7 +8,7 @@ from typing import Generic, TypeVar
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from .charging import ChargeMode, ChargingState, ServiceEventChargingError
+from .charging import ChargeMode, ChargingState
 
 
 class ServiceEventName(StrEnum):
@@ -25,6 +25,12 @@ class ServiceEventName(StrEnum):
     CLIMATISATION_COMPLETED = "climatisation-completed"
     DEPARTURE_READY = "departure-ready"
     DEPARTURE_STATUS_CHANGED = "departure-status-changed"
+    DEPARTURE_ERROR_PLUG = "departure-error-plug"
+
+
+class ServiceEventError(StrEnum):
+    STOPPED_DEVICE = "STOPPED_DEVICE"
+    CLIMA = "CLIMA"
 
 
 @dataclass
@@ -115,14 +121,25 @@ class ServiceEventChargingData(ServiceEventData):
         default=None,
         metadata=field_options(alias="timeToFinish", deserialize=_deserialize_time_to_finish),
     )
-    error_code: ServiceEventChargingError | None = field(
-        default=None, metadata=field_options(alias="errorCode")
-    )
 
 
 @dataclass
 class ServiceEventWithChargingData(ServiceEvent):
     data: ServiceEventChargingData
+
+
+@dataclass
+class ServiceEventErrorData(ServiceEventData):
+    """Error code inside charging or departure service."""
+
+    error_code: ServiceEventError | None = field(
+        default=None, metadata=field_options(alias="errorCode")
+    )
+
+
+@dataclass
+class ServiceEventWithErrorData(ServiceEvent):
+    data: ServiceEventErrorData
 
 
 class UnexpectedChargeModeError(Exception):

--- a/tests/fixtures/events/service_event_charging_charging_error.json
+++ b/tests/fixtures/events/service_event_charging_charging_error.json
@@ -5,7 +5,7 @@
     "producer": "SKODA_MHUB",
     "name": "charging-error",
     "data": {
-	"errorCode": "STOPPED_DEVICE",
+        "errorCode": "STOPPED_DEVICE",
         "userId": "ad0d7945-4814-43d0-801f-charging-error",
         "vin": "TMBAXXXXXXXXXXXXX"
     }

--- a/tests/fixtures/events/service_event_departure_error_plug.json
+++ b/tests/fixtures/events/service_event_departure_error_plug.json
@@ -1,0 +1,12 @@
+{
+    "version": 1,
+    "traceId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "timestamp": "2024-11-15T13:14:41Z",
+    "producer": "SKODA_MHUB",
+    "name": "departure-error-plug",
+    "data": {
+        "errorCode": "CLIMA",
+        "userId": "ad0d7945-4814-43d0-801f-departure-error-plug",
+        "vin": "TMBAXXXXXXXXXXXXX"
+    }
+}

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -286,7 +286,6 @@ async def test_subscribe_event(
                     soc=None,
                     charged_range=None,
                     time_to_finish=None,
-                    error_code=None,
                 ),
             ),
         ),

--- a/tests/test_service_event.py
+++ b/tests/test_service_event.py
@@ -13,10 +13,11 @@ from myskoda.models.service_event import (
     ChargingState,
     ServiceEvent,
     ServiceEventChargingData,
-    ServiceEventChargingError,
+    ServiceEventErrorData,
     ServiceEventData,
     ServiceEventName,
     ServiceEventWithChargingData,
+    ServiceEventWithErrorData,
 )
 
 FIXTURES_DIR = Path(__file__).parent.joinpath("fixtures")
@@ -32,6 +33,7 @@ def load_service_events() -> list[str]:
         "events/service_event_charging_charging_error.json",
         "events/service_event_departure_ready.json",
         "events/service_event_departure_status_changed.json",
+        "events/service_event_departure_error_plug.json",
     ]:
         json_file = FIXTURES_DIR / path
         service_events.append(json_file.read_text())
@@ -45,7 +47,6 @@ def test_parse_service_events(service_events: list[str]) -> None:
         if event.name in [
             ServiceEventName.CHANGE_SOC,
             ServiceEventName.CHARGING_STATUS_CHANGED,
-            ServiceEventName.CHARGING_ERROR,
         ]:
             try:
                 event = ServiceEventWithChargingData.from_json(service_event)
@@ -67,11 +68,26 @@ def test_parse_service_events(service_events: list[str]) -> None:
                     user_id=f"ad0d7945-4814-43d0-801f-{event.name.value}",
                     vin="TMBAXXXXXXXXXXXXX",
                 )
-            elif event.name == ServiceEventName.CHARGING_ERROR:
-                assert event.data == ServiceEventChargingData(
+        elif event.name in [
+            ServiceEventName.CHARGING_ERROR,
+            ServiceEventName.DEPARTURE_ERROR_PLUG,
+        ]:
+            try:
+                event = ServiceEventWithErrorData.from_json(service_event)
+            except ValueError:
+                event = ServiceEvent.from_json(service_event)
+
+            if event.name == ServiceEventName.CHARGING_ERROR:
+                assert event.data == ServiceEventErrorData(
                     user_id=f"ad0d7945-4814-43d0-801f-{event.name.value}",
                     vin="TMBAXXXXXXXXXXXXX",
-                    error_code=ServiceEventChargingError.STOPPED_DEVICE,
+                    error_code=ServiceEventError.STOPPED_DEVICE,
+                )
+            elif event.name == ServiceEventName.DEPARTURE_ERROR_PLUG:
+                assert event.data == ServiceEventErrorData(
+                    user_id=f"ad0d7945-4814-43d0-801f-{event.name.value}",
+                    vin="TMBAXXXXXXXXXXXXX",
+                    error_code=ServiceEventError.CLIMA,
                 )
         else:
             assert event.data == ServiceEventData(

--- a/tests/test_service_event.py
+++ b/tests/test_service_event.py
@@ -13,6 +13,7 @@ from myskoda.models.service_event import (
     ChargingState,
     ServiceEvent,
     ServiceEventChargingData,
+    ServiceEventError,
     ServiceEventErrorData,
     ServiceEventData,
     ServiceEventName,


### PR DESCRIPTION
I discovered another error that was published via MQTT:
```
2025-01-30 17:30:34 python myskoda.mqtt[2702] DEBUG Message (service-event) received for TMBAXXXXXXXXXXXXX on topic departure: b'{"version":1,"traceId":"7b586354-fc7b-474a-bd6a-d69bbec13fa1","timestamp":"2025-01-30T16:30:30Z","producer":"SKODA_MHUB","name":"departure-error-plug","data":{"errorCode":"CLIMA","userId":"00000000-0000-0000-0000-000000000000","vin":"TMBAXXXXXXXXXXXXX"}}'
```
To add handling for this, I'd suggest to move the "charging-error" out of "models/charging.py" back into "models/service-event.py" and revert the adding of "error-code" to "ServiceEventChargingData" and to use a separate "ServiceEventErrorData" instead.

I'm not totally sure, why or when this error was fired - but maybe this opens the door to handle more MQTT published errors in future.