### PR TITLE
Cache and update the last Vehicle

### DIFF
--- a/myskoda/models/air_conditioning.py
+++ b/myskoda/models/air_conditioning.py
@@ -13,7 +13,7 @@ from mashumaro.config import (
 )
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from .common import ChargerLockedState, ConnectionState, OnOffState, Side, Weekday
+from .common import BaseResponse, ChargerLockedState, ConnectionState, OnOffState, Side, Weekday
 
 
 class TemperatureUnit(StrEnum):
@@ -145,7 +145,7 @@ class WindowHeating(DataClassORJSONMixin):
 
 
 @dataclass
-class AirConditioning(DataClassORJSONMixin):
+class AirConditioning(BaseResponse):
     """Information related to air conditioning."""
 
     timers: list[AirConditioningTimer]
@@ -190,4 +190,3 @@ class AirConditioning(DataClassORJSONMixin):
     outside_temperature: OutsideTemperature | None = field(
         default=None, metadata=field_options(alias="outsideTemperature")
     )
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/auxiliary_heating.py
+++ b/myskoda/models/auxiliary_heating.py
@@ -15,6 +15,7 @@ from .air_conditioning import (
     OutsideTemperature,
     TargetTemperature,
 )
+from .common import BaseResponse
 
 
 class AuxiliaryState(StrEnum):
@@ -72,7 +73,7 @@ class AuxiliaryHeatingTimer(AirConditioningTimer):
 
 
 @dataclass
-class AuxiliaryHeating(DataClassORJSONMixin):
+class AuxiliaryHeating(BaseResponse):
     """Information related to auxiliary heating."""
 
     timers: list[AuxiliaryHeatingTimer]
@@ -96,4 +97,3 @@ class AuxiliaryHeating(DataClassORJSONMixin):
     outside_temperature: OutsideTemperature | None = field(
         default=None, metadata=field_options(alias="outsideTemperature")
     )
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/charging.py
+++ b/myskoda/models/charging.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from .common import ActiveState, CaseInsensitiveStrEnum, EnabledState
+from .common import ActiveState, BaseResponse, CaseInsensitiveStrEnum, EnabledState
 
 
 class ChargingErrorType(StrEnum):
@@ -113,7 +113,7 @@ class ChargingStatus(DataClassORJSONMixin):
 
 
 @dataclass
-class Charging(DataClassORJSONMixin):
+class Charging(BaseResponse):
     """Information related to charging an EV."""
 
     errors: list[ChargingError]
@@ -125,4 +125,3 @@ class Charging(DataClassORJSONMixin):
         default=None, metadata=field_options(alias="carCapturedTimestamp")
     )
     status: ChargingStatus | None = field(default=None)
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/common.py
+++ b/myskoda/models/common.py
@@ -1,6 +1,7 @@
 """Common models used in multiple responses."""
 
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import StrEnum
 
 from mashumaro import field_options
@@ -99,3 +100,13 @@ class Weekday(StrEnum):
     FRIDAY = "FRIDAY"
     SATURDAY = "SATURDAY"
     SUNDAY = "SUNDAY"
+
+
+@dataclass
+class BaseResponse(DataClassORJSONMixin):
+    """Base class for all API response models.
+
+    All responses have the current timestamp injected.
+    """
+
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC), kw_only=True)

--- a/myskoda/models/departure.py
+++ b/myskoda/models/departure.py
@@ -10,7 +10,7 @@ from mashumaro.config import BaseConfig
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 from .air_conditioning import TemperatureUnit, TimerMode
-from .common import Weekday
+from .common import BaseResponse, Weekday
 
 
 @dataclass
@@ -89,7 +89,7 @@ class DepartureSettings(DataClassORJSONMixin):
 
 
 @dataclass
-class DepartureInfo(DataClassORJSONMixin):
+class DepartureInfo(BaseResponse):
     """Information related to Departure."""
 
     car_captured_timestamp: datetime | None = field(
@@ -107,4 +107,3 @@ class DepartureInfo(DataClassORJSONMixin):
     timers: list[DepartureTimer] | None = field(
         default=None, metadata=field_options(alias="timers")
     )
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/driving_range.py
+++ b/myskoda/models/driving_range.py
@@ -7,6 +7,8 @@ from enum import StrEnum
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
+from .common import BaseResponse
+
 
 class EngineType(StrEnum):
     DIESEL = "diesel"
@@ -31,7 +33,7 @@ class EngineRange(DataClassORJSONMixin):
 
 
 @dataclass
-class DrivingRange(DataClassORJSONMixin):
+class DrivingRange(BaseResponse):
     car_captured_timestamp: datetime = field(metadata=field_options(alias="carCapturedTimestamp"))
     car_type: EngineType = field(metadata=field_options(alias="carType"))
     primary_engine_range: EngineRange = field(metadata=field_options(alias="primaryEngineRange"))
@@ -42,4 +44,3 @@ class DrivingRange(DataClassORJSONMixin):
         default=None, metadata=field_options(alias="totalRangeInKm")
     )
     ad_blue_range: int | None = field(default=None, metadata=field_options(alias="adBlueRange"))
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/garage.py
+++ b/myskoda/models/garage.py
@@ -2,13 +2,13 @@
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
 from enum import StrEnum
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from myskoda.models.info import CompositeRender, Render, VehicleState
+from .common import BaseResponse
+from .info import CompositeRender, Render, VehicleState
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,9 +47,8 @@ class GarageEntry(DataClassORJSONMixin):
 
 
 @dataclass
-class Garage(DataClassORJSONMixin):
+class Garage(BaseResponse):
     """Contents of the users Garage."""
 
     vehicles: list[GarageEntry] | None = field(default=None)
     errors: list[GarageError] | None = field(default=None)
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/health.py
+++ b/myskoda/models/health.py
@@ -7,6 +7,8 @@ from enum import StrEnum
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
+from .common import BaseResponse
+
 
 class WarningLightCategory(StrEnum):
     ASSISTANCE = "ASSISTANCE"
@@ -33,10 +35,9 @@ class WarningLight(DataClassORJSONMixin):
 
 
 @dataclass
-class Health(DataClassORJSONMixin):
+class Health(BaseResponse):
     """Information about the car's health (currently only mileage)."""
 
     warning_lights: list[WarningLight] = field(metadata=field_options(alias="warningLights"))
     mileage_in_km: int | None = field(default=None, metadata=field_options(alias="mileageInKm"))
     captured_at: datetime | None = field(default=None, metadata=field_options(alias="capturedAt"))
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/info.py
+++ b/myskoda/models/info.py
@@ -2,12 +2,14 @@
 
 import logging
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date
 from enum import StrEnum
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 from mashumaro.mixins.yaml import DataClassYAMLMixin
+
+from .common import BaseResponse
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -263,7 +265,7 @@ class CompositeRender(DataClassORJSONMixin):
 
 
 @dataclass
-class Info(DataClassORJSONMixin):
+class Info(BaseResponse):
     """Basic vehicle information."""
 
     state: VehicleState
@@ -285,7 +287,6 @@ class Info(DataClassORJSONMixin):
     )
     license_plate: str | None = field(default=None, metadata=field_options(alias="licensePlate"))
     errors: list[Error] | None = field(default=None)
-    timestamp: datetime | None = field(default=None)
 
     def has_capability(self, cap: CapabilityId) -> bool:
         """Check for a capability.

--- a/myskoda/models/maintenance.py
+++ b/myskoda/models/maintenance.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from .common import Address, Coordinates, Weekday
+from .common import Address, BaseResponse, Coordinates, Weekday
 
 
 @dataclass
@@ -82,7 +82,7 @@ class ServicePartner(DataClassORJSONMixin):
 
 
 @dataclass
-class Maintenance(DataClassORJSONMixin):
+class Maintenance(BaseResponse):
     maintenance_report: MaintenanceReport | None = field(
         default=None, metadata=field_options(alias="maintenanceReport")
     )
@@ -92,4 +92,3 @@ class Maintenance(DataClassORJSONMixin):
     preferred_service_partner: ServicePartner | None = field(
         default=None, metadata=field_options(alias="preferredServicePartner")
     )
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/position.py
+++ b/myskoda/models/position.py
@@ -1,13 +1,12 @@
 """Models for responses of api/v2/vehicle-status/{vin}/driving-range."""
 
 from dataclasses import dataclass, field
-from datetime import datetime
 from enum import StrEnum
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from .common import Address, Coordinates
+from .common import Address, BaseResponse, Coordinates
 
 
 class PositionType(StrEnum):
@@ -33,9 +32,8 @@ class Error(DataClassORJSONMixin):
 
 
 @dataclass
-class Positions(DataClassORJSONMixin):
+class Positions(BaseResponse):
     """Positional information (GPS) for the vehicle and other things."""
 
     errors: list[Error]
     positions: list[Position]
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/spin.py
+++ b/myskoda/models/spin.py
@@ -1,11 +1,12 @@
 """Models for responses of api/v1/spin/verify."""
 
 from dataclasses import dataclass, field
-from datetime import datetime
 from enum import StrEnum
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+from .common import BaseResponse
 
 
 class VerificationStatus(StrEnum):
@@ -25,9 +26,8 @@ class SpinStatus(DataClassORJSONMixin):
 
 
 @dataclass
-class Spin(DataClassORJSONMixin):
+class Spin(BaseResponse):
     verification_status: VerificationStatus = field(
         metadata=field_options(alias="verificationStatus")
     )
     spin_status: SpinStatus | None = field(default=None, metadata=field_options(alias="spinStatus"))
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/status.py
+++ b/myskoda/models/status.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs, urlparse
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from myskoda.models.common import DoorLockedState, OnOffState, OpenState
+from .common import BaseResponse, DoorLockedState, OnOffState, OpenState
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ class Renders(DataClassORJSONMixin):
 
 
 @dataclass
-class Status(DataClassORJSONMixin):
+class Status(BaseResponse):
     """Current status information for a vehicle."""
 
     detail: Detail
@@ -74,7 +74,6 @@ class Status(DataClassORJSONMixin):
     car_captured_timestamp: datetime | None = field(
         default=None, metadata=field_options(alias="carCapturedTimestamp")
     )
-    timestamp: datetime | None = field(default=None)
 
     def _extract_window_door_state_list_from_url(self) -> list[int]:
         """Extract window/door states from renders url.

--- a/myskoda/models/trip_statistics.py
+++ b/myskoda/models/trip_statistics.py
@@ -1,11 +1,13 @@
 """Models for responses of api/v2/vehicle-status/{vin}."""
 
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date
 from enum import StrEnum
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+from .common import BaseResponse
 
 
 class VehicleType(StrEnum):
@@ -44,7 +46,7 @@ class StatisticsEntry(DataClassORJSONMixin):
 
 
 @dataclass
-class TripStatistics(DataClassORJSONMixin):
+class TripStatistics(BaseResponse):
     vehicle_type: VehicleType = field(metadata=field_options(alias="vehicleType"))
     detailed_statistics: list[StatisticsEntry] = field(
         metadata=field_options(alias="detailedStatistics")
@@ -73,4 +75,3 @@ class TripStatistics(DataClassORJSONMixin):
     overall_travel_time_in_min: int | None = field(
         default=None, metadata=field_options(alias="overallTravelTimeInMin")
     )
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/models/user.py
+++ b/myskoda/models/user.py
@@ -2,11 +2,13 @@
 
 import logging
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date
 from enum import StrEnum
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+from .common import BaseResponse
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +38,7 @@ def drop_unknown_capabilities(value: list[dict]) -> list[UserCapability]:
 
 
 @dataclass
-class User(DataClassORJSONMixin):
+class User(BaseResponse):
     capabilities: list[UserCapability] = field(
         metadata=field_options(deserialize=drop_unknown_capabilities)
     )
@@ -55,4 +57,3 @@ class User(DataClassORJSONMixin):
     )
     phone: str | None = None
     country: str | None = None
-    timestamp: datetime | None = field(default=None)

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -55,6 +55,8 @@ from .vehicle import Vehicle
 
 _LOGGER = logging.getLogger(__name__)
 
+type Vin = str
+
 
 async def trace_response(
     _session: ClientSession,
@@ -83,6 +85,7 @@ class MySkoda:
     mqtt: MySkodaMqttClient | None = None
     authorization: Authorization
     ssl_context: SSLContext | None = None
+    vehicles: dict[Vin, Vehicle]
 
     def __init__(  # noqa: D107, PLR0913
         self,
@@ -93,6 +96,7 @@ class MySkoda:
         mqtt_broker_port: int | None = None,
         mqtt_enable_ssl: bool | None = None,
     ) -> None:
+        self.vehicles: dict[Vin, Vehicle] = {}
         self.session = session
         self.authorization = Authorization(session)
         self.rest_api = RestApi(self.session, self.authorization)
@@ -408,37 +412,39 @@ class MySkoda:
         info = await self.get_info(vin)
         maintenance = await self.get_maintenance(vin)
 
-        vehicle = Vehicle(info, maintenance)
+        if vin in self.vehicles:
+            self.vehicles[vin].info = info
+            self.vehicles[vin].maintenance = maintenance
+        else:
+            self.vehicles[vin] = Vehicle(info, maintenance)
 
         for capa in capabilities:
             if info.is_capability_available(capa):
-                await self._request_capability_data(vehicle, vin, capa)
+                await self._request_capability_data(vin, capa)
 
-        return vehicle
+        return self.vehicles[vin]
 
-    async def _request_capability_data(
-        self, vehicle: Vehicle, vin: str, capa: CapabilityId
-    ) -> None:
+    async def _request_capability_data(self, vin: str, capa: CapabilityId) -> None:
         """Request specific capability data from MySkoda API."""
         try:
             match capa:
                 case CapabilityId.AIR_CONDITIONING:
-                    vehicle.air_conditioning = await self.get_air_conditioning(vin)
+                    self.vehicles[vin].air_conditioning = await self.get_air_conditioning(vin)
                 case CapabilityId.AUXILIARY_HEATING:
-                    vehicle.auxiliary_heating = await self.get_auxiliary_heating(vin)
+                    self.vehicles[vin].auxiliary_heating = await self.get_auxiliary_heating(vin)
                 case CapabilityId.CHARGING:
-                    vehicle.charging = await self.get_charging(vin)
+                    self.vehicles[vin].charging = await self.get_charging(vin)
                 case CapabilityId.PARKING_POSITION:
-                    vehicle.positions = await self.get_positions(vin)
+                    self.vehicles[vin].positions = await self.get_positions(vin)
                 case CapabilityId.STATE:
-                    vehicle.status = await self.get_status(vin)
-                    vehicle.driving_range = await self.get_driving_range(vin)
+                    self.vehicles[vin].status = await self.get_status(vin)
+                    self.vehicles[vin].driving_range = await self.get_driving_range(vin)
                 case CapabilityId.TRIP_STATISTICS:
-                    vehicle.trip_statistics = await self.get_trip_statistics(vin)
+                    self.vehicles[vin].trip_statistics = await self.get_trip_statistics(vin)
                 case CapabilityId.VEHICLE_HEALTH_INSPECTION:
-                    vehicle.health = await self.get_health(vin)
+                    self.vehicles[vin].health = await self.get_health(vin)
                 case CapabilityId.DEPARTURE_TIMERS:
-                    vehicle.departure_info = await self.get_departure_timers(vin)
+                    self.vehicles[vin].departure_info = await self.get_departure_timers(vin)
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning("Requesting %s failed: %s, continue", capa, err)
 

--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -136,7 +136,6 @@ class RestApi:
             anonymization_fn=anonymize_info,
         )
         result = self._deserialize(raw, Info.from_json)
-        result.timestamp = datetime.now(UTC)
         url = anonymize_url(url) if anonymize else url
         return GetEndpointResult(url=url, raw=raw, result=result)
 
@@ -269,7 +268,6 @@ class RestApi:
             anonymization_fn=anonymize_user,
         )
         result = self._deserialize(raw, User.from_json)
-        result.timestamp = datetime.now(UTC)
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_garage(self, anonymize: bool = False) -> GetEndpointResult[Garage]:

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -26,12 +26,12 @@ async def test_report_get(
     responses.get(url=url_pattern, body=report.raw)
 
     result = await myskoda.get_endpoint(VIN, report.endpoint, anonymize=True)
+    result = result.result.to_dict()
 
-    # Remove any timestamps
-    if result.result.timestamp:
-        result.result.timestamp = None
+    # Remove timestamp
+    result["timestamp"] = None
 
-    assert result.result.to_dict() == report.result
+    assert result == report.result
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -2,7 +2,9 @@
 
 import json
 import re
+from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from aioresponses import aioresponses
@@ -319,6 +321,9 @@ async def test_get_departure_timers(
             url=url_pattern,
             body=departure_timer,
         )
-        get_departure_timers_result = await myskoda.get_departure_timers(target_vin)
 
-        assert get_departure_timers_result == DepartureInfo.from_json(departure_timer)
+        with patch("myskoda.models.common.datetime") as mock_datetime:
+            mock_datetime.now.return_value = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+            get_departure_timers_result = await myskoda.get_departure_timers(target_vin)
+
+            assert get_departure_timers_result == DepartureInfo.from_json(departure_timer)


### PR DESCRIPTION
I hit a wall in https://github.com/skodaconnect/homeassistant-myskoda/pull/632 trying to selectively exclude updates of the Vehicle.health based on the last timestamp:

When intentionally excluding specific capabilities (~endpoints) the
problem is that the corresponding Vehicle fields will be None in the
returned Vehicle.

So either the client/caller must have the knowledge of the
capability->endpoint->field mapping and stitch together the previous and
new Vehicle, or the MySkoda class must store the last Vehicle(s) and
update what can be updated. The second option seems much cleaner and
keeps internal logic encapsulated in the myskoda lib.

I've used the opportunity to refactor how the timestamp field is set. Rather than allowing it to be None and explicitly having to set it in the RestApi methods, we can use `field.default_factory` to automatically set the timestamp when an instance is created. Also create a common base model to deduplicate the timestamp field.