### PR TITLE
Force new Vehicle to be returned

### DIFF
--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -6,6 +6,7 @@ This class provides all methods to operate on the API and MQTT broker.
 import logging
 from asyncio import gather, timeout
 from collections.abc import Awaitable, Callable
+from copy import deepcopy
 from datetime import UTC, datetime
 from ssl import SSLContext
 from traceback import format_exc
@@ -422,7 +423,7 @@ class MySkoda:
             if info.is_capability_available(capa):
                 await self._request_capability_data(vin, capa)
 
-        return self.vehicles[vin]
+        return deepcopy(self.vehicles[vin])
 
     async def _request_capability_data(self, vin: str, capa: CapabilityId) -> None:
         """Request specific capability data from MySkoda API."""


### PR DESCRIPTION
Ensure a new Vehicle object is returned by
get_vehicle/get_partial_vehicle.

If the same object is always returned, even if the content changes, the HA Coordinator doesn't know there was an update and thus doesn't trigger the entity listeners.

Fixes https://github.com/skodaconnect/homeassistant-myskoda/issues/651