### PR TITLE
Fix type hint for mqtt callbacks

### DIFF
--- a/myskoda/cli/mqtt.py
+++ b/myskoda/cli/mqtt.py
@@ -39,7 +39,7 @@ async def subscribe(ctx: Context) -> None:
     """Connect to the MQTT broker and listen for messages."""
     myskoda: MySkoda = ctx.obj["myskoda"]
 
-    def on_event(event: Event) -> None:
+    async def on_event(event: Event) -> None:
         ctx.obj["print"](event.to_dict())
 
     myskoda.subscribe(on_event)

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -5,7 +5,7 @@ This class provides all methods to operate on the API and MQTT broker.
 
 import logging
 from asyncio import gather, timeout
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Coroutine
 from copy import deepcopy
 from datetime import UTC, datetime
 from ssl import SSLContext
@@ -153,7 +153,7 @@ class MySkoda:
             await self.mqtt.connect(user.id, vehicles)
         _LOGGER.debug("MySkoda ready.")
 
-    def subscribe(self, callback: Callable[[Event], None | Awaitable[None]]) -> None:
+    def subscribe(self, callback: Callable[[Event], Coroutine[Any, Any, None]]) -> None:
         """Listen for events emitted by MySkoda's MQTT broker."""
         if self.mqtt is None:
             raise MqttDisabledError

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -289,7 +289,7 @@ async def test_subscribe_event(
         ),
     ]
 
-    def on_event(event: Event) -> None:
+    async def on_event(event: Event) -> None:
         events.append(event)
         if len(events) == len(messages):
             future.set_result(None)


### PR DESCRIPTION
Just a minor type hinting fix I ran into while trying to understand something else, and learning more about async types.

`subscribe()` is passed an async function, which is callable returning a `Coroutine`, not an `Awaitable`, and definitely not `None`.

This then avoids the rogue cast to `Any` when passing the result of calling the callback function into `asyncio.create_task`.