### PR TITLE
Readme: Adding await to disconnect in basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ async def main():
         await myskoda.connect(USERNAME, PASSWORD)
         for vin in await myskoda.list_vehicle_vins():
             print(vin)
-        myskoda.disconnect()
+        await myskoda.disconnect()
 
 asyncio.run(main())
 ```


### PR DESCRIPTION
This commit fixes the error shown below when using the basic example from the README. 

> RuntimeWarning: coroutine 'MySkoda.disconnect' was never awaited
>   myskoda.disconnect()
> RuntimeWarning: Enable tracemalloc to get the object allocation traceback