### PR TITLE
fix: ignore timestamps present in fixture

### DIFF
--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -30,6 +30,8 @@ async def test_report_get(
 
     # Remove timestamp
     result["timestamp"] = None
+    if (res := report.result) is not None and "timestamp" in res:
+        res["timestamp"] = None
 
     assert result == report.result
 


### PR DESCRIPTION
Fixtures from #419 have a `timestamp`, which is correct, but breaks tests.

This PR removes `timestamp` comparisons by forcing them to `None`