### PR TITLE
fix: add vehicle_connection_status to fixture generator

### DIFF
--- a/myskoda/models/fixtures.py
+++ b/myskoda/models/fixtures.py
@@ -27,6 +27,7 @@ class Endpoint(StrEnum):
     DRIVING_RANGE = "driving_range"
     TRIP_STATISTICS = "trip_statistics"
     DEPARTURE_INFO = "departure_info"
+    VEHICLE_CONNECTION_STATUS = "vehicle_connection_status"
     ALL = "all"
 
 

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -657,6 +657,7 @@ class MySkoda:
             Endpoint.DRIVING_RANGE: self.rest_api.get_driving_range,
             Endpoint.TRIP_STATISTICS: self.rest_api.get_trip_statistics,
             Endpoint.DEPARTURE_INFO: self.rest_api.get_departure_timers,
+            Endpoint.VEHICLE_CONNECTION_STATUS: self.rest_api.get_vehicle_connection_status,
         }
 
         # Look up the method, or raise an error if unsupported


### PR DESCRIPTION
When adding the vehicle_connection_status to the library, I forgot to add it to the fixtures as well, as discovered by a user on Discord in https://discord.com/channels/877164727636230184/877167631935897621/1371858211937845250

This adds the new status to fixtures as well