### PR TITLE
fix: add missing LOYALTY_PROGRAM user capability

### DIFF
--- a/myskoda/models/user.py
+++ b/myskoda/models/user.py
@@ -14,14 +14,15 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class UserCapabilityId(StrEnum):
-    SPIN_MANAGEMENT = "SPIN_MANAGEMENT"
-    THIRD_PARTY_OFFERS = "THIRD_PARTY_OFFERS"
+    LOYALTY_PROGRAM = "LOYALTY_PROGRAM"
     MARKETING_CONSENT = "MARKETING_CONSENT"
     MARKETING_CONSENT_GENERIC = "MARKETING_CONSENT_GENERIC"
     MARKETING_CONSENT_SAD = "MARKETING_CONSENT_SAD"
-    MARKETING_CONSENT_SAD_THIRD_PARTY = "MARKETING_CONSENT_SAD_THIRD_PARTY"
     MARKETING_CONSENT_SAD_DEALERS = "MARKETING_CONSENT_SAD_DEALERS"
+    MARKETING_CONSENT_SAD_THIRD_PARTY = "MARKETING_CONSENT_SAD_THIRD_PARTY"
+    SPIN_MANAGEMENT = "SPIN_MANAGEMENT"
     TEST_DRIVE = "TEST_DRIVE"
+    THIRD_PARTY_OFFERS = "THIRD_PARTY_OFFERS"
 
 
 @dataclass
@@ -29,18 +30,18 @@ class UserCapability(DataClassORJSONMixin):
     id: UserCapabilityId
 
 
-def drop_unknown_capabilities(value: list[dict]) -> list[UserCapability]:
+def drop_unknown_usercapabilities(value: list[dict]) -> list[UserCapability]:
     """Drop any unknown usercapabilities and log a message."""
     unknown_capabilities = [c for c in value if c["id"] not in UserCapabilityId]
     if unknown_capabilities:
-        _LOGGER.info("Dropping unknown capabilities: %s", unknown_capabilities)
+        _LOGGER.info("Dropping unknown usercapabilities: %s", unknown_capabilities)
     return [UserCapability.from_dict(c) for c in value if c["id"] in UserCapabilityId]
 
 
 @dataclass
 class User(BaseResponse):
     capabilities: list[UserCapability] = field(
-        metadata=field_options(deserialize=drop_unknown_capabilities)
+        metadata=field_options(deserialize=drop_unknown_usercapabilities)
     )
     email: str
     id: str


### PR DESCRIPTION
Ran across it while restarting the integration today.

Additionally:
- Sort the Enum alphabetically
- rename `drop_unknown_capabilities` to `drop_unknown_usercapabilities` to be more precise