### PR TITLE
fix: set version with importlib

### DIFF
--- a/myskoda/__version__.py
+++ b/myskoda/__version__.py
@@ -1,3 +1,5 @@
-"""Version for MySkoda package. Used for dynamic versioning with uv."""
+"""The package version is automatically set by uv-dynamic-versioning."""
 
-__version__ = "0.0.0"
+import importlib.metadata
+
+__version__ = importlib.metadata.version(__name__.split(".")[0])


### PR DESCRIPTION
uv-dynamic-versioning doesn't actually update __version__.py

See https://github.com/ninoseki/uv-dynamic-versioning/issues/9

Fixes #432

Test:

```
❯ grep library_version fixtures/parked.yaml
library_version: 2.0.0.post1.dev0+3673795
```