### PR TITLE
feat: add the maintenance-report, summary of maintenance from a different endpoint

### DIFF
--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -230,7 +230,7 @@ head -n 9 docs/api_endpoints.md && tail -n +10 docs/api_endpoints.md | sort --fi
 | EnergyX | GET    | api/v3/vehicle-maintenance/service-partners/{servicePartnerId}             |       |         |
 | EnergyX | GET    | api/v3/vehicle-maintenance/service-partners/{servicePartnerId}/encoded-url |       |         |
 | EnergyX | GET    | api/v3/vehicle-maintenance/vehicles/{vin}                                  | ✅     |         |
-| EnergyX | GET    | api/v3/vehicle-maintenance/vehicles/{vin}/report                           |       | <pre lang="json"> {"capturedAt":"2025-03-19T07:33:41.681Z","inspectionDueInDays":84,"mileageInKm":91870}</pre> |
+| EnergyX | GET    | api/v3/vehicle-maintenance/vehicles/{vin}/report                           | ✅     | <pre lang="json"> {"capturedAt":"2025-03-19T07:33:41.681Z","inspectionDueInDays":84,"mileageInKm":91870}</pre> |
 | EnergyX | POST   | api/v3/vehicle-maintenance/vehicles/{vin}/service-booking                  |       |         |
 | EnergyX | DELETE | api/v3/vehicle-maintenance/vehicles/{vin}/service-partner                  |       |         |
 | EnergyX | PUT    | api/v3/vehicle-maintenance/vehicles/{vin}/service-partner                  |       |         |

--- a/myskoda/cli/__init__.py
+++ b/myskoda/cli/__init__.py
@@ -57,6 +57,7 @@ from myskoda.cli.requests import (
     info,
     list_vehicles,
     maintenance,
+    maintenance_report,
     positions,
     status,
     trip_statistics,
@@ -155,6 +156,7 @@ cli.add_command(health)
 cli.add_command(charging)
 cli.add_command(charging_profiles)
 cli.add_command(maintenance)
+cli.add_command(maintenance_report)
 cli.add_command(driving_range)
 cli.add_command(user)
 cli.add_command(trip_statistics)

--- a/myskoda/cli/requests.py
+++ b/myskoda/cli/requests.py
@@ -103,6 +103,15 @@ async def maintenance(ctx: Context, vin: str, anonymize: bool) -> None:
 @click.argument("vin")
 @click.option("anonymize", "--anonymize", help="Strip all personal data.", is_flag=True)
 @click.pass_context
+async def maintenance_report(ctx: Context, vin: str, anonymize: bool) -> None:
+    """Print the vehicle's maintenance report."""
+    await handle_request(ctx, ctx.obj["myskoda"].get_maintenance_report, vin, anonymize)
+
+
+@click.command()
+@click.argument("vin")
+@click.option("anonymize", "--anonymize", help="Strip all personal data.", is_flag=True)
+@click.pass_context
 async def driving_range(ctx: Context, vin: str, anonymize: bool) -> None:
     """Print the vehicle's estimated driving range information."""
     await handle_request(ctx, ctx.obj["myskoda"].get_driving_range, vin, anonymize)

--- a/myskoda/models/maintenance.py
+++ b/myskoda/models/maintenance.py
@@ -11,7 +11,7 @@ from .common import Address, BaseResponse, Coordinates, Weekday
 
 
 @dataclass
-class MaintenanceReport(DataClassORJSONMixin):
+class MaintenanceReport(BaseResponse):
     captured_at: datetime = field(metadata=field_options(alias="capturedAt"))
     mileage_in_km: int | None = field(default=None, metadata=field_options(alias="mileageInKm"))
     inspection_due_in_days: int | None = field(
@@ -148,8 +148,3 @@ class Maintenance(BaseResponse):
     customer_service: CustomerService | None = field(
         default=None, metadata=field_options(alias="customerService")
     )
-
-
-@dataclass
-class MaintenanceReportResponse(BaseResponse, MaintenanceReport):
-    pass

--- a/myskoda/models/maintenance.py
+++ b/myskoda/models/maintenance.py
@@ -92,3 +92,8 @@ class Maintenance(BaseResponse):
     preferred_service_partner: ServicePartner | None = field(
         default=None, metadata=field_options(alias="preferredServicePartner")
     )
+
+
+@dataclass
+class MaintReport(BaseResponse, MaintenanceReport):
+    pass

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -85,7 +85,7 @@ from .models.event import (
 )
 from .models.health import Health
 from .models.info import CapabilityId, Info
-from .models.maintenance import Maintenance
+from .models.maintenance import Maintenance, MaintReport
 from .models.position import Positions
 from .models.spin import Spin
 from .models.status import Status
@@ -255,10 +255,12 @@ class MySkoda:
         """Load and return a partial vehicle, based on list of capabilities."""
         info = await self.get_info(vin)
         maintenance = await self.get_maintenance(vin)
+        maintenance_report = await self.get_maintenance_report(vin)
 
         if vin in self._vehicles:
             self._vehicles[vin].info = info
             self._vehicles[vin].maintenance = maintenance
+            self._vehicles[vin].maintenance_report = maintenance_report
         else:
             self._vehicles[vin] = Vehicle(info=info, maintenance=maintenance)
 
@@ -313,8 +315,12 @@ class MySkoda:
         return (await self.rest_api.get_trip_statistics(vin, anonymize=anonymize)).result
 
     async def get_maintenance(self, vin: Vin, anonymize: bool = False) -> Maintenance:
-        """Retrieve maintenance report."""
+        """Retrieve maintenance report, settings and history."""
         return (await self.rest_api.get_maintenance(vin, anonymize=anonymize)).result
+
+    async def get_maintenance_report(self, vin: Vin, anonymize: bool = False) -> MaintReport:
+        """Retrieve maintenance report only."""
+        return (await self.rest_api.get_maintenance_report(vin, anonymize=anonymize)).result
 
     async def get_health(self, vin: Vin, anonymize: bool = False) -> Health:
         """Retrieve health information for the specified vehicle."""

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -85,7 +85,7 @@ from .models.event import (
 )
 from .models.health import Health
 from .models.info import CapabilityId, Info
-from .models.maintenance import Maintenance, MaintenanceReportResponse
+from .models.maintenance import Maintenance, MaintenanceReport
 from .models.position import Positions
 from .models.spin import Spin
 from .models.status import Status
@@ -316,9 +316,7 @@ class MySkoda:
         """Retrieve maintenance report, settings and history."""
         return (await self.rest_api.get_maintenance(vin, anonymize=anonymize)).result
 
-    async def get_maintenance_report(
-        self, vin: Vin, anonymize: bool = False
-    ) -> MaintenanceReportResponse:
+    async def get_maintenance_report(self, vin: Vin, anonymize: bool = False) -> MaintenanceReport:
         """Retrieve maintenance report only."""
         return (await self.rest_api.get_maintenance_report(vin, anonymize=anonymize)).result
 

--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -49,7 +49,7 @@ from .models.departure import DepartureInfo, DepartureTimer
 from .models.driving_range import DrivingRange
 from .models.health import Health
 from .models.info import Info
-from .models.maintenance import Maintenance, MaintenanceReportResponse
+from .models.maintenance import Maintenance, MaintenanceReport
 from .models.position import Positions
 from .models.spin import Spin
 from .models.status import Status
@@ -267,7 +267,7 @@ class RestApi:
 
     async def get_maintenance_report(
         self, vin: str, anonymize: bool = False
-    ) -> GetEndpointResult[MaintenanceReportResponse]:
+    ) -> GetEndpointResult[MaintenanceReport]:
         """Retrieve just the maintenance report."""
         url = f"/v3/vehicle-maintenance/vehicles/{vin}/report"
         raw = self.process_json(
@@ -275,7 +275,7 @@ class RestApi:
             anonymize=anonymize,
             anonymization_fn=anonymize_maintenance,
         )
-        result = self._deserialize(raw, MaintenanceReportResponse.from_json)
+        result = self._deserialize(raw, MaintenanceReport.from_json)
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_health(self, vin: str, anonymize: bool = False) -> GetEndpointResult[Health]:

--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -49,7 +49,7 @@ from .models.departure import DepartureInfo, DepartureTimer
 from .models.driving_range import DrivingRange
 from .models.health import Health
 from .models.info import Info
-from .models.maintenance import Maintenance
+from .models.maintenance import Maintenance, MaintReport
 from .models.position import Positions
 from .models.spin import Spin
 from .models.status import Status
@@ -254,7 +254,7 @@ class RestApi:
     async def get_maintenance(
         self, vin: str, anonymize: bool = False
     ) -> GetEndpointResult[Maintenance]:
-        """Retrieve maintenance report."""
+        """Retrieve maintenance report, settings and history."""
         url = f"/v3/vehicle-maintenance/vehicles/{vin}"
         raw = self.process_json(
             data=await self._make_get_request(url),
@@ -263,6 +263,19 @@ class RestApi:
         )
         result = self._deserialize(raw, Maintenance.from_json)
         url = anonymize_url(url) if anonymize else url
+        return GetEndpointResult(url=url, raw=raw, result=result)
+
+    async def get_maintenance_report(
+        self, vin: str, anonymize: bool = False
+    ) -> GetEndpointResult[MaintReport]:
+        """Retrieve just the maintenance report."""
+        url = f"/v3/vehicle-maintenance/vehicles/{vin}/report"
+        raw = self.process_json(
+            data=await self._make_get_request(url),
+            anonymize=anonymize,
+            anonymization_fn=anonymize_maintenance,
+        )
+        result = self._deserialize(raw, MaintReport.from_json)
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_health(self, vin: str, anonymize: bool = False) -> GetEndpointResult[Health]:

--- a/myskoda/vehicle.py
+++ b/myskoda/vehicle.py
@@ -7,7 +7,7 @@ from .models.departure import DepartureInfo
 from .models.driving_range import DrivingRange
 from .models.health import Health
 from .models.info import CapabilityId, Info
-from .models.maintenance import Maintenance
+from .models.maintenance import Maintenance, MaintReport
 from .models.position import Positions
 from .models.status import Status
 from .models.trip_statistics import TripStatistics
@@ -26,6 +26,7 @@ class Vehicle:
     driving_range: DrivingRange | None = None
     trip_statistics: TripStatistics | None = None
     maintenance: Maintenance
+    maintenance_report: MaintReport | None = None
     health: Health | None = None
     departure_info: DepartureInfo | None = None
     connection_status: VehicleConnectionStatus | None = None

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -30,8 +30,13 @@ async def test_report_get(
 
     # Remove timestamp
     result["timestamp"] = None
-    if (res := report.result) is not None and "timestamp" in res:
-        res["timestamp"] = None
+    if (res := report.result) is not None:
+        if "timestamp" in res:
+            res["timestamp"] = None
+        mr = res.get("maintenance_report")
+        if mr:
+            mr["timestamp"] = None
+            result["maintenance_report"]["timestamp"] = None
 
     assert result == report.result
 


### PR DESCRIPTION
After #446 the `maintenance` data we have available becomes more and more.

This implements the `maintenance_report`.
Think of the `maintenance_report` as a short summary of `maintenance`, coming from the `/v3/vehicle-maintenance/vehicles/{vin}/report` endpoint.

We can implement a different caching strategy here, since this part of the data is expected to change at least once per trip. Other data in the `maintenance` endpoint is expected to be more static than this and certainly doesn't need to be refreshed more than once in 24h