### PR TITLE
fix: pass the HA ssl_context into the mqtt client

### DIFF
--- a/myskoda/mqtt.py
+++ b/myskoda/mqtt.py
@@ -116,6 +116,7 @@ class MySkodaMqttClient:
         self,
         authorization: Authorization,
         mqtt_client: AbstractMqttClientWrapper | None = None,
+        ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         self.authorization = authorization
         self.vehicle_vins = []
@@ -128,7 +129,7 @@ class MySkodaMqttClient:
                 port=MQTT_BROKER_PORT,
                 identifier="Id" + str(APP_UUID) + "#" + str(uuid.uuid4()),
                 logger=_LOGGER,
-                tls_context=_SSL_CONTEXT,
+                tls_context=ssl_context if ssl_context else _SSL_CONTEXT,
                 keepalive=MQTT_KEEPALIVE,
                 clean_session=True,
             )

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -165,7 +165,7 @@ class MySkoda:
         self.session = session
         self.authorization = MySkodaAuthorization(session)
         self.rest_api = RestApi(self.session, self.authorization)
-        self.ssl_context = ssl_context  # TODO @dvx76: this isn't used anywhere?
+        self.ssl_context = ssl_context
         if mqtt_enabled:
             self.mqtt = self._create_mqtt_client()
 
@@ -788,7 +788,7 @@ class MySkoda:
                 task.add_done_callback(background_tasks.discard)
 
     def _create_mqtt_client(self) -> MySkodaMqttClient:
-        mqtt = MySkodaMqttClient(authorization=self.authorization)
+        mqtt = MySkodaMqttClient(authorization=self.authorization, ssl_context=self.ssl_context)
         mqtt.subscribe(self._on_mqtt_event)
         return mqtt
 


### PR DESCRIPTION
Used to be the case but was accidentally dropped when migrating to aiomqtt.