### PR TITLE
fix: add missing IconColor values

### DIFF
--- a/myskoda/models/maintenance.py
+++ b/myskoda/models/maintenance.py
@@ -93,7 +93,14 @@ class BookingType(StrEnum):
 
 
 class IconColor(StrEnum):
+    black = "BLACK"
+    blue = "BLUE"
+    cyan = "CYAN"
+    green = "GREEN"
+    magenta = "MAGENTA"
+    red = "RED"
     white = "WHITE"
+    yellow = "YELLOW"
 
 
 @dataclass


### PR DESCRIPTION
Yellow is definitely used now but seems like a good idea to just include all base ASCII color names.

Source:

```
`mashumaro.exceptions.InvalidFieldValue: Field "warnings" of type list[CarWarning] in Booking has invalid value [{'iconColor': 'YELLOW', 'iconName': 'H_1_07', 'messageId': 'A4E9', 'notificationId': 42217, 'text': 'Error: Airbag'}]`
```