### PR TITLE
fix: replace deprecated PROTOCOL_TLS with PROTOCOL_TLS_CLIENT

### DIFF
--- a/myskoda/mqtt.py
+++ b/myskoda/mqtt.py
@@ -37,7 +37,7 @@ APP_UUID = uuid.uuid4()
 
 def _create_ssl_context() -> ssl.SSLContext:
     """Create a SSL context for the MQTT connection."""
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     context.load_default_certs()
     return context
 


### PR DESCRIPTION
As per https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS:

`Deprecated since version 3.10: TLS clients and servers require different default settings for secure communication. The generic TLS protocol constant is deprecated in favor of [PROTOCOL_TLS_CLIENT](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT) and [PROTOCOL_TLS_SERVER](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_SERVER).
`

We require python3.13 these days for this library, so should be safe to update to the newer constant.

Tested in my deployment