### PR TITLE
fix: add coordinates to chargingprofile and anonimyze output when needed

### DIFF
--- a/myskoda/anonymize.py
+++ b/myskoda/anonymize.py
@@ -44,6 +44,7 @@ SERVICE_PARTNER = {
     "location": LOCATION,
 }
 FORMATTED_ADDRESS = "1600 Pennsylvania Ave NW, Washington, DC 20500, USA"
+PROFILE_NAME = "Example Profile"
 
 
 def anonymize_info(data: dict) -> dict:
@@ -106,6 +107,11 @@ def anonymize_chargingprofiles(data: dict) -> dict:
     Returns:
         dict
     """
+    if len(data["chargingProfiles"] > 1):
+        for profile in data["chargingProfiles"]:
+            profile["name"].update(PROFILE_NAME)
+            if "location" in profile:
+                profile["location"].update(LOCATION)
     return data
 
 

--- a/myskoda/models/chargingprofiles.py
+++ b/myskoda/models/chargingprofiles.py
@@ -8,7 +8,7 @@ from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 from .air_conditioning import TimerMode
 from .charging import MaxChargeCurrent, PlugUnlockMode
-from .common import BaseResponse, Weekday
+from .common import BaseResponse, Coordinates, Weekday
 
 
 @dataclass
@@ -70,6 +70,7 @@ class ChargingProfile(DataClassORJSONMixin):
         metadata=field_options(alias="preferredChargingTimes")
     )
     timers: list[ChargingTimers]
+    location: Coordinates | None = field(default=None)
 
 
 @dataclass


### PR DESCRIPTION
This adds a missing anonimyzation function to the charging profile data, which had become necessary as some models return position information for the charging profiles.

Fixes #477 