### PR TITLE
chore: add chargingstate error

### DIFF
--- a/myskoda/models/charging.py
+++ b/myskoda/models/charging.py
@@ -47,6 +47,7 @@ class ChargingState(CaseInsensitiveStrEnum):
     CONNECT_CABLE = "CONNECT_CABLE"
     CONSERVING = "CONSERVING"
     CHARGING = "CHARGING"
+    ERROR = "ERROR"
 
 
 class ChargeType(StrEnum):


### PR DESCRIPTION
Encountered this is in my own logs.
"ERROR"-state can occur when the wallsocket isn't providing any power, for instance when using smart charging schedules.