### PR TITLE
fix: add dataclass for vehicle-connection-offline message

### DIFF
--- a/myskoda/models/event/vehicle.py
+++ b/myskoda/models/event/vehicle.py
@@ -96,6 +96,11 @@ class VehicleEventConnectionOnline(VehicleEvent):
 
 
 @dataclass(frozen=True)
+class VehicleEventConnectionOffline(VehicleEvent):
+    name = VehicleEventName.VEHICLE_CONNECTION_OFFLINE
+
+
+@dataclass(frozen=True)
 class VehicleEventIgnitionStatusChanged(VehicleEvent):
     name = VehicleEventName.VEHICLE_IGNITION_STATUS_CHANGED
     data: VehicleEventVehicleIgnitionStatusData


### PR DESCRIPTION
As reported in skodaconnect/homeassistant-myskoda#899, the addition of `vehicle-connection-offline` in #464 was incomplete.

This PR adds the missing `dataclass`