### PR TITLE
test: update test_generated to force loading fixtures in utf-8 encoding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,15 +10,32 @@ We use [**uv**](https://github.com/astral-sh/uv) as our preferred Python package
 
 ### Step 1: Install `uv`
 
+**MacOS/Linux**
+
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
+**Windows**
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
 ### Step 2: Create and activate a virtual environment
+
+**MacOS/Linux**
 
 ```bash
 uv venv
 source .venv/bin/activate
+```
+
+**Windows**
+
+```bash
+uv venv
+source .venv\Scripts\activate
 ```
 
 ### Step 3: Install dependencies

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -45,7 +45,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     parameters = []
 
     for file in FIXTURES_DIR.glob("**/*.yaml"):
-        text = file.read_text()
+        text = file.read_text(encoding="utf-8")
         fixture = Fixture.from_yaml(text)
         if fixture.reports is None:
             continue


### PR DESCRIPTION
pytest was returning errors converting Škoda in the title on Windows OS.

```
  -         'title': 'Å\xa0koda Octavia',
  ?                   ^^^^^
  +         'title': 'Škoda Octavia',
```
  
Add some lines in the contribution document, because on Windows there are some differences for the setup of UV.