### PR TITLE
chore(ci): increase interval for python dependencies, add github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,8 @@ updates:
   - package-ecosystem: "uv" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
       interval: "weekly"


### PR DESCRIPTION
This changes the scan interval for python dependencies from daily to weekly, so we catch those quicker.
Adds dependency scanning for github actions, to keep our ci pipelines up to date

A warning about nodejs inside the pipelines being outdated triggered this change.