### PR TITLE
security(deps): bump pyjwt to 2.12.1 to fix CVE-2026-32597

### DIFF
--- a/myskoda/auth/authorization.py
+++ b/myskoda/auth/authorization.py
@@ -308,7 +308,7 @@ class Authorization(ABC):
             raise NotAuthorizedError
 
         meta = jwt.decode(self.idk_session.access_token, options={"verify_signature": False})
-        expiry = datetime.fromtimestamp(float(meta.get("exp")), tz=UTC)
+        expiry = datetime.fromtimestamp(float(meta.get("exp", "0")), tz=UTC)
         return datetime.now(tz=UTC) + timedelta(minutes=10) > expiry
 
     def is_refresh_token_expired(self, refresh_token: str | None = None) -> bool:
@@ -321,7 +321,7 @@ class Authorization(ABC):
         else:
             meta = jwt.decode(self.idk_session.refresh_token, options={"verify_signature": False})
 
-        expiry = datetime.fromtimestamp(float(meta.get("exp")), tz=UTC)
+        expiry = datetime.fromtimestamp(float(meta.get("exp", "0")), tz=UTC)
         return datetime.now(tz=UTC) + timedelta(minutes=1) > expiry
 
     async def _perform_refresh_token(self) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "aiomqtt ~=2.2",
   "asyncio ~=3.4",
   "mashumaro[orjson] ~=3.13",
-  "pyjwt ~=2.10",
+  "pyjwt ~=2.12",
   "pyyaml ~=6.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -710,7 +710,7 @@ requires-dist = [
     { name = "mkdocs-literate-nav", marker = "extra == 'docs'", specifier = "~=0.6" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.26.1,<1.1.0" },
     { name = "pygments", marker = "extra == 'cli'", specifier = "~=2.18" },
-    { name = "pyjwt", specifier = "~=2.10" },
+    { name = "pyjwt", specifier = "~=2.12" },
     { name = "python-dateutil", marker = "extra == 'cli'", specifier = "~=2.9" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "termcolor", marker = "extra == 'cli'", specifier = "~=3.0" },
@@ -900,11 +900,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The expiry field has transitioned from optional to mandatory with this upgrade. We set a missing expiry field to "0", so we interpret this as "always invalidated", just to be sure.