### PR TITLE
chore(deps): relax dependencies to indicate minimal required versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+
+    # Ignore the main runtime dependencies
+    # We update these manually as new code features require it
+    ignore:
+      - dependency-name: "aiohttp"
+      - dependency-name: "aiomqtt"
+      - dependency-name: "mashumaro"
+      - dependency-name: "pyjwt"
+      - dependency-name: "pyyaml"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.13.0"
 dependencies = [
-  "aiohttp ~=3.11",
-  "aiomqtt ~=2.2",
-  "mashumaro[orjson] ~=3.13",
-  "pyjwt ~=2.10,<2.11",
-  "pyyaml ~=6.0",
+  "aiohttp >=3.11",
+  "aiomqtt >=2.2",
+  "mashumaro[orjson] >=3.13",
+  "pyjwt >=2.10",
+  "pyyaml >=6.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -696,19 +696,19 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = "~=3.11" },
-    { name = "aiomqtt", specifier = "~=2.2" },
+    { name = "aiohttp", specifier = ">=3.11" },
+    { name = "aiomqtt", specifier = ">=2.2" },
     { name = "asyncclick", marker = "extra == 'cli'", specifier = "~=8.1" },
     { name = "coloredlogs", marker = "extra == 'cli'", specifier = "~=15.0" },
-    { name = "mashumaro", extras = ["orjson"], specifier = "~=3.13" },
+    { name = "mashumaro", extras = ["orjson"], specifier = ">=3.13" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "~=1.6" },
     { name = "mkdocs-gen-files", marker = "extra == 'docs'", specifier = "~=0.5" },
     { name = "mkdocs-literate-nav", marker = "extra == 'docs'", specifier = "~=0.6" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.26.1,<1.1.0" },
     { name = "pygments", marker = "extra == 'cli'", specifier = "~=2.18" },
-    { name = "pyjwt", specifier = "~=2.10,<2.11" },
+    { name = "pyjwt", specifier = ">=2.10" },
     { name = "python-dateutil", marker = "extra == 'cli'", specifier = "~=2.9" },
-    { name = "pyyaml", specifier = "~=6.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "termcolor", marker = "extra == 'cli'", specifier = "~=3.0" },
 ]
 provides-extras = ["cli", "docs"]


### PR DESCRIPTION
This relaxes dependency requirements to indicate minimal required versions required for better upstream handling.
This way, applications using this library can decide their own pinning strategy better.