### PR TITLE
feat(cli): add raw-request, fix session handling

### DIFF
--- a/myskoda/cli/__init__.py
+++ b/myskoda/cli/__init__.py
@@ -43,6 +43,7 @@ from myskoda.cli.operations import (
     unlock,
     wakeup,
 )
+from myskoda.cli.raw_request import raw_request
 from myskoda.cli.requests import (
     air_conditioning,
     all_charging_sessions,
@@ -128,6 +129,9 @@ async def cli(  # noqa: PLR0913
     if trace:
         trace_configs.append(TRACE_CONFIG)
 
+    if ctx.resilient_parsing:
+        return
+
     auth_usage_str = "Provide --refresh-token or both --user and --password."
     if not refresh_token and (not username or not password):
         raise click.UsageError(auth_usage_str)
@@ -144,25 +148,11 @@ async def cli(  # noqa: PLR0913
     ctx.obj["myskoda"] = myskoda
     ctx.obj["session"] = session
 
+    async def _disconnect() -> None:
+        await myskoda.disconnect()
+        await session.close()
 
-@cli.result_callback()
-@click.pass_context
-async def disconnect(  # noqa: PLR0913
-    ctx: Context,
-    result: None,  # noqa: ARG001
-    username: str | None,  # noqa: ARG001
-    password: str | None,  # noqa: ARG001
-    refresh_token: str | None,  # noqa: ARG001
-    verbose: bool,  # noqa: ARG001
-    output_format: Format,  # noqa: ARG001
-    trace: bool,  # noqa: ARG001
-    disable_mqtt: bool,  # noqa: ARG001
-) -> None:
-    myskoda: MySkoda = ctx.obj["myskoda"]
-    session: ClientSession = ctx.obj["session"]
-
-    await myskoda.disconnect()
-    await session.close()
+    ctx.call_on_close(_disconnect)
 
 
 cli.add_command(list_vehicles)
@@ -218,6 +208,7 @@ cli.add_command(set_ac_timer)
 cli.add_command(set_aux_timer)
 cli.add_command(software_update_status)
 cli.add_command(driving_score)
+cli.add_command(raw_request)
 
 
 if __name__ == "__main__":

--- a/myskoda/cli/raw_request.py
+++ b/myskoda/cli/raw_request.py
@@ -5,8 +5,9 @@ import sys
 from typing import TYPE_CHECKING
 
 import asyncclick as click
-from aiohttp.client_exceptions import ClientResponseError
 from asyncclick.core import Context
+
+from myskoda.cli.utils import handle_request
 
 if TYPE_CHECKING:
     from myskoda import MySkoda
@@ -56,16 +57,13 @@ async def raw_request(ctx: Context, path: str, vin: str | None, method: str | No
 
     method = ("POST" if body is not None else "GET") if method is None else method.upper()
 
-    try:
+    async def _do_request() -> dict | None:
         text = await myskoda.rest_api.raw_request(url=path, method=method, json=body)
-    except ClientResponseError as e:
-        ctx.obj["print"]({"error": e.status, "message": e.message, "url": str(e.request_info.url)})
-        return
+        if not text:
+            return {"status": "ok"}
+        return json.loads(text)
 
-    if text:
-        try:
-            ctx.obj["print"](json.loads(text))
-        except json.JSONDecodeError:
-            print(text)
-    else:
-        ctx.obj["print"]({"status": "ok"})
+    try:
+        await handle_request(ctx, _do_request)
+    except json.JSONDecodeError as e:
+        ctx.obj["print"]({"error": "JSONDecodeError", "message": str(e)})

--- a/myskoda/cli/raw_request.py
+++ b/myskoda/cli/raw_request.py
@@ -1,0 +1,71 @@
+"""Command for sending raw requests to the MySkoda API."""
+
+import json
+import sys
+from typing import TYPE_CHECKING
+
+import asyncclick as click
+from aiohttp.client_exceptions import ClientResponseError
+from asyncclick.core import Context
+
+if TYPE_CHECKING:
+    from myskoda import MySkoda
+
+
+@click.command()
+@click.argument("path")
+@click.option("vin", "--vin", help="VIN to substitute into {vin} placeholders in the path.")
+@click.option(
+    "method",
+    "--method",
+    "-X",
+    help="HTTP method. Defaults to GET, or POST when data is provided on stdin.",
+    type=click.Choice(["GET", "POST", "PUT", "DELETE", "PATCH"], case_sensitive=False),
+    default=None,
+)
+@click.pass_context
+async def raw_request(ctx: Context, path: str, vin: str | None, method: str | None) -> None:
+    """Send a raw authenticated request to the MySkoda API.
+
+    PATH is the API path, e.g. /v2/garage or /v1/charging/{vin}/set-charging-current.
+    The base URL (https://mysmob.api.connect.skoda-auto.cz/api) is prepended automatically.
+
+    JSON data can be piped via stdin; when data is present the method defaults to POST.
+
+    Examples:
+
+    \b
+        myskoda [...] raw-request /v2/garage
+        echo '{"chargingCurrent": 20}' | myskoda [...] raw-request --vin TMBJB9NY \\
+            '/v1/charging/{vin}/set-charging-current'
+    """
+    myskoda: MySkoda = ctx.obj["myskoda"]
+
+    if vin:
+        path = path.replace("{vin}", vin)
+
+    body: dict | None = None
+    if not sys.stdin.isatty():
+        raw_stdin = sys.stdin.read().strip()
+        if raw_stdin:
+            try:
+                body = json.loads(raw_stdin)
+            except json.JSONDecodeError as e:
+                msg = f"stdin is not valid JSON: {e}"
+                raise click.BadParameter(msg) from e
+
+    method = ("POST" if body is not None else "GET") if method is None else method.upper()
+
+    try:
+        text = await myskoda.rest_api.raw_request(url=path, method=method, json=body)
+    except ClientResponseError as e:
+        ctx.obj["print"]({"error": e.status, "message": e.message, "url": str(e.request_info.url)})
+        return
+
+    if text:
+        try:
+            ctx.obj["print"](json.loads(text))
+        except json.JSONDecodeError:
+            print(text)
+    else:
+        ctx.obj["print"]({"status": "ok"})

--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -116,6 +116,10 @@ class RestApi:
             _LOGGER.exception("Invalid status for %s request to %s: %d", method, url, err.status)
             raise
 
+    async def raw_request(self, url: str, method: str, json: dict | None = None) -> str:
+        """Send an authenticated request to the given API path."""
+        return await self._make_request(url=url, method=method, json=json)
+
     async def _make_get_request[T](self, url: str) -> str:
         return await self._make_request(url=url, method="GET")
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -775,7 +775,7 @@ async def test_set_departure_timer(
 
         # Extract and assert the captured request body
         assert mock_request.called
-        request_args, request_kwargs = mock_request.call_args
+        _, request_kwargs = mock_request.call_args
         body = request_kwargs.get("data") or request_kwargs.get("json")
         assert body is not None
         # check only the timer as deviceDateTime can't be verified

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from aiohttp import ClientResponseError
 from aioresponses import aioresponses
 
 from myskoda.models.common import OpenState
@@ -15,6 +16,7 @@ from myskoda.models.driving_score import DrivingScoreResult
 from myskoda.models.status import DoorWindowState
 from myskoda.models.trip_statistics import VehicleType
 from myskoda.myskoda import MySkoda
+from myskoda.rest_api import RestApi
 from myskoda.utils import to_iso8601
 
 FIXTURES_DIR = Path(__file__).parent.joinpath("fixtures")
@@ -741,3 +743,50 @@ async def test_vehicle_renders(
                 assert layer.type == layer_json["type"]
                 assert layer.url == layer_json["url"]
                 assert layer.view_point == layer_json["viewPoint"]
+
+
+BASE_URL = "https://mysmob.api.connect.skoda-auto.cz/api"
+HTTP_NOT_FOUND = 404
+
+
+@pytest.mark.asyncio
+async def test_raw_request_get(api: RestApi, responses: aioresponses) -> None:
+    """raw_request GET returns the response body as a string."""
+    body = '{"key": "value"}'
+    responses.get(url=f"{BASE_URL}/v1/some/path", body=body)
+
+    result = await api.raw_request(url="/v1/some/path", method="GET")
+
+    assert result == body
+
+
+@pytest.mark.asyncio
+async def test_raw_request_post_with_body(api: RestApi, responses: aioresponses) -> None:
+    """raw_request POST sends JSON body and returns the response body."""
+    response_body = '{"status": "ok"}'
+    responses.post(url=f"{BASE_URL}/v1/some/path", body=response_body)
+
+    result = await api.raw_request(url="/v1/some/path", method="POST", json={"chargingCurrent": 20})
+
+    assert result == response_body
+
+
+@pytest.mark.asyncio
+async def test_raw_request_empty_response(api: RestApi, responses: aioresponses) -> None:
+    """raw_request returns an empty string when the response body is empty."""
+    responses.post(url=f"{BASE_URL}/v1/some/path", body="")
+
+    result = await api.raw_request(url="/v1/some/path", method="POST")
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_raw_request_http_error(api: RestApi, responses: aioresponses) -> None:
+    """raw_request raises ClientResponseError on HTTP error responses."""
+    responses.get(url=f"{BASE_URL}/v1/some/path", status=HTTP_NOT_FOUND)
+
+    with pytest.raises(ClientResponseError) as exc_info:
+        await api.raw_request(url="/v1/some/path", method="GET")
+
+    assert exc_info.value.status == HTTP_NOT_FOUND


### PR DESCRIPTION
Fixes #469 

Adds a `raw-request` command to the CLI for sending authenticated requests to API endpoints

## Examples
### GET (default)
`myskoda [authentication params] raw-request /v2/garage`

### POST (default when stdin is present)
```bash
echo '{"chargingCurrent" :20}' | myskoda [authentication params] raw-request --vin TMBXXX \
    '/v1/charging/{vin}/set-charging-current'
```

Additionally fixes two bugs in CLI session handling that were causing unneeded authentications (when specifying `--help` and authentication details) and unclean session teardowns