### PR TITLE
feat: enable ansi formatting only when outputting to console

### DIFF
--- a/myskoda/cli/utils.py
+++ b/myskoda/cli/utils.py
@@ -1,22 +1,22 @@
 """Utilities for the command line interface."""
 
 import json
+import sys
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from functools import update_wrapper
-import sys
 from typing import TYPE_CHECKING, Any
 
 import asyncclick as click
-from pygments.lexer import Lexer
 import yaml
 from aiohttp.client_exceptions import ClientResponseError
 from asyncclick.core import Context
 from dateutil.parser import isoparse
 from pygments import highlight
 from pygments.formatters import TerminalFormatter
+from pygments.lexer import Lexer
 from pygments.lexers import JsonLexer, YamlLexer
 
 if TYPE_CHECKING:

--- a/myskoda/cli/utils.py
+++ b/myskoda/cli/utils.py
@@ -6,9 +6,11 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from functools import update_wrapper
+import sys
 from typing import TYPE_CHECKING, Any
 
 import asyncclick as click
+from pygments.lexer import Lexer
 import yaml
 from aiohttp.client_exceptions import ClientResponseError
 from asyncclick.core import Context
@@ -57,14 +59,18 @@ class Format(StrEnum):
     YAML = "yaml"
 
 
+def highlight_for_console(text: str, lexer: Lexer) -> str:
+    if sys.stdout.isatty():
+        return highlight(text, lexer, TerminalFormatter())
+    return text
+
+
 def print_json(data: dict) -> None:
-    print(
-        highlight(json.dumps(data, indent=4, ensure_ascii=False), JsonLexer(), TerminalFormatter())
-    )
+    print(highlight_for_console(json.dumps(data, indent=4, ensure_ascii=False), JsonLexer()))
 
 
 def print_yaml(data: dict) -> None:
-    print(highlight(yaml.dump(data, allow_unicode=True), YamlLexer(), TerminalFormatter()))
+    print(highlight_for_console(yaml.dump(data, allow_unicode=True), YamlLexer()))
 
 
 def iso8601_datetime(


### PR DESCRIPTION
Hi,

Currently, it's difficult to use `grep` or `jq` to process the `myskoda` application output because it always inserts ANSI codes into the output stream.
This fix enables ANSI codes only when `myskoda` prints directly to the console.