### PR TITLE
fix: added NO_UPDATE_AVAILABLE to SoftwareStatus

### DIFF
--- a/myskoda/models/software_status.py
+++ b/myskoda/models/software_status.py
@@ -9,6 +9,7 @@ from .common import BaseResponse, CaseInsensitiveStrEnum
 
 
 class SoftwareStatus(CaseInsensitiveStrEnum):
+    NO_UPDATE_AVAILABLE = "NO_UPDATE_AVAILABLE"
     UPDATE_SUCCESSFUL = "UPDATE_SUCCESSFUL"
 
 

--- a/tests/fixtures/enyaq/software-version-no-update.json
+++ b/tests/fixtures/enyaq/software-version-no-update.json
@@ -1,0 +1,4 @@
+{
+  "status": "NO_UPDATE_AVAILABLE",
+  "currentSoftwareVersion": "5.6"
+}

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -500,6 +500,7 @@ def load_software_updates() -> list[str]:
     software_updates = []
     for path in [
         "enyaq/software-version.json",
+        "enyaq/software-version-no-update.json",
     ]:
         with FIXTURES_DIR.joinpath(path).open() as file:
             software_updates.append(file.read())
@@ -522,10 +523,11 @@ async def test_software_updates(
         get_software_version_result = await myskoda.get_software_update_status(target_vin)
 
         assert get_software_version_result.status == software_updates_json["status"]
-        assert (
-            get_software_version_result.release_notes_url
-            == software_updates_json["releaseNotesUrl"]
-        )
+        if "releaseNotesUrl" in software_updates_json:
+            assert (
+                get_software_version_result.release_notes_url
+                == software_updates_json["releaseNotesUrl"]
+            )
         assert (
             get_software_version_result.current_software_version
             == software_updates_json["currentSoftwareVersion"]


### PR DESCRIPTION
My new Enyaq returns `NO_UPDATE_AVAILABLE` for update status as apparently it's still up-to-date ;)

JSON also doesn't contain "release_notes_url" or "car_captured_timestamp", so they are returned as None by the API. Seems fine for me, so I made the unit test assert optional accordingly.