### PR TITLE
feat: add get_charging_statistics endpoint

### DIFF
--- a/myskoda/cli/__init__.py
+++ b/myskoda/cli/__init__.py
@@ -52,6 +52,7 @@ from myskoda.cli.requests import (
     charging,
     charging_history,
     charging_profiles,
+    charging_statistics,
     connection_status,
     departure_timers,
     driving_range,
@@ -178,6 +179,7 @@ cli.add_command(auth)
 cli.add_command(auxiliary_heating)
 cli.add_command(charging_history)
 cli.add_command(charging_profiles)
+cli.add_command(charging_statistics)
 cli.add_command(charging)
 cli.add_command(connection_status)
 cli.add_command(departure_timers)

--- a/myskoda/cli/requests.py
+++ b/myskoda/cli/requests.py
@@ -329,6 +329,28 @@ async def all_charging_sessions(ctx: Context, vin: str) -> None:
 
 @click.command()
 @click.argument("vin")
+@click.option(
+    "--start",
+    "start",
+    help="ISO8601 compatible start date (required)",
+    callback=iso8601_datetime,
+    required=True,
+)
+@click.option(
+    "--end",
+    "end",
+    help="ISO8601 compatible end date (required)",
+    callback=iso8601_datetime,
+    required=True,
+)
+@click.pass_context
+async def charging_statistics(ctx: Context, vin: str, start: datetime, end: datetime) -> None:
+    """Print charging session statistics from the cariad endpoint."""
+    await handle_request(ctx, ctx.obj["myskoda"].get_charging_statistics, vin, start, end)
+
+
+@click.command()
+@click.argument("vin")
 @click.option("anonymize", "--anonymize", help="Strip all personal data.", is_flag=True)
 @click.pass_context
 async def maintenance(ctx: Context, vin: str, anonymize: bool) -> None:

--- a/myskoda/const.py
+++ b/myskoda/const.py
@@ -6,6 +6,7 @@ REDIRECT_URI = "myskoda://redirect/login/"
 
 BASE_URL_SKODA = "https://mysmob.api.connect.skoda-auto.cz"
 BASE_URL_IDENT = "https://identity.vwgroup.io"
+BASE_URL_CHARGING = "https://prod.emea.mobile.charging.cariad.digital"
 
 MQTT_BROKER_HOST = "mqtt.messagehub.de"
 MQTT_BROKER_PORT = 8883

--- a/myskoda/models/charging_history.py
+++ b/myskoda/models/charging_history.py
@@ -1,13 +1,21 @@
-"""Models for responses of api/v1/charging/{vin}/history."""
+"""Models for charging history API responses."""
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime
 from enum import StrEnum
+from uuid import UUID
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 from .common import BaseResponse
+
+
+def _parse_local_datetime(value: str | None) -> datetime | None:
+    """Parse a user-local formatted datetime string (dd.MM.yy HH:mm) as a naive datetime."""
+    if value is None:
+        return None
+    return datetime.strptime(value, "%d.%m.%y %H:%M")  # noqa: DTZ007
 
 
 class ChargingCurrentType(StrEnum):
@@ -35,3 +43,86 @@ class ChargingPeriod(DataClassORJSONMixin):
 class ChargingHistory(BaseResponse):
     next_cursor: datetime | None = field(default=None, metadata=field_options(alias="nextCursor"))
     periods: list[ChargingPeriod] = field(default_factory=list)
+
+
+# Request models for the new POST /charging_statistics endpoint
+
+
+@dataclass
+class ChargingStatisticsFilterOption(DataClassORJSONMixin):
+    filter_type: str = field(metadata=field_options(alias="filterType"))
+    id: str
+
+
+@dataclass
+class ChargingStatisticsRequest(DataClassORJSONMixin):
+    started_after: date = field(metadata=field_options(alias="startedAfter"))
+    started_before: date = field(metadata=field_options(alias="startedBefore"))
+    selected_filter_options: list[ChargingStatisticsFilterOption] = field(
+        default_factory=list, metadata=field_options(alias="selectedFilterOptions")
+    )
+    capabilities: list[str] = field(default_factory=list)
+    fetch_filter_options: bool = field(
+        default=True, metadata=field_options(alias="fetchFilterOptions")
+    )
+    is_active_sessions_enabled: bool = field(
+        default=True, metadata=field_options(alias="isActiveSessionsEnabled")
+    )
+    is_export_enabled: bool = field(default=True, metadata=field_options(alias="isExportEnabled"))
+
+
+# Response models for the new POST /charging_statistics endpoint
+
+
+@dataclass
+class ChargingStatisticsSessionDetails(DataClassORJSONMixin):
+    session_id: UUID = field(metadata=field_options(alias="sessionId"))
+    charging_power_type: ChargingCurrentType = field(
+        metadata=field_options(alias="chargingPowerType")
+    )
+    is_active_session: bool = field(metadata=field_options(alias="isActiveSession"))
+    formatted_total_energy: str | None = field(
+        default=None, metadata=field_options(alias="formattedTotalEnergy")
+    )
+    # Timestamps are in user-local time (no UTC offset); stored as naive datetimes.
+    charging_start_time: datetime | None = field(
+        default=None,
+        metadata=field_options(
+            alias="formattedChargingStartTime", deserialize=_parse_local_datetime
+        ),
+    )
+    charging_end_time: datetime | None = field(
+        default=None,
+        metadata=field_options(alias="formattedChargingEndTime", deserialize=_parse_local_datetime),
+    )
+    formatted_total_charging_time: str | None = field(
+        default=None, metadata=field_options(alias="formattedTotalChargingTime")
+    )
+    formatted_active_charging_time: str | None = field(
+        default=None, metadata=field_options(alias="formattedActiveChargingTime")
+    )
+    formatted_start_soc: str | None = field(
+        default=None, metadata=field_options(alias="formattedStartSoc")
+    )
+    formatted_end_soc: str | None = field(
+        default=None, metadata=field_options(alias="formattedEndSoc")
+    )
+
+
+@dataclass
+class ChargingStatisticsEntry(DataClassORJSONMixin):
+    details: ChargingStatisticsSessionDetails
+
+
+@dataclass
+class ChargingStatisticsSection(DataClassORJSONMixin):
+    title: str
+    entries: list[ChargingStatisticsEntry] = field(default_factory=list)
+
+
+@dataclass
+class ChargingStatistics(DataClassORJSONMixin):
+    month_sections: list[ChargingStatisticsSection] = field(
+        default_factory=list, metadata=field_options(alias="monthSections")
+    )
+    csv_file: str | None = field(default=None, metadata=field_options(alias="csvFile"))

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -68,7 +68,7 @@ from .models.auxiliary_heating import (
     AuxiliaryHeatingTimer,
 )
 from .models.charging import ChargeMode, Charging
-from .models.charging_history import ChargingHistory, ChargingSession
+from .models.charging_history import ChargingHistory, ChargingSession, ChargingStatistics
 from .models.chargingprofiles import ChargingProfiles
 from .models.common import Vin
 from .models.departure import DepartureInfo, DepartureTimer
@@ -386,6 +386,15 @@ class MySkoda:
             cursor = charging_history.result.next_cursor
 
         return total_sessions
+
+    async def get_charging_statistics(
+        self,
+        vin: Vin,
+        start: datetime,
+        end: datetime,
+    ) -> ChargingStatistics:
+        """Retrieve charging session statistics from the cariad endpoint."""
+        return (await self.rest_api.get_charging_statistics(vin, start, end)).result
 
     async def get_status(self, vin: Vin, anonymize: bool = False) -> Status:
         """Retrieve the current status for the specified vehicle."""

--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -47,7 +47,12 @@ from myskoda.anonymize import (
 )
 
 from .auth.authorization import Authorization
-from .const import BASE_URL_SKODA, MYSKODA_APP_VERSION, REQUEST_TIMEOUT_IN_SECONDS
+from .const import (
+    BASE_URL_CHARGING,
+    BASE_URL_SKODA,
+    MYSKODA_APP_VERSION,
+    REQUEST_TIMEOUT_IN_SECONDS,
+)
 from .models.air_conditioning import (
     AirConditioning,
     AirConditioningAtUnlock,
@@ -58,7 +63,12 @@ from .models.air_conditioning import (
 )
 from .models.auxiliary_heating import AuxiliaryConfig, AuxiliaryHeating, AuxiliaryHeatingTimer
 from .models.charging import ChargeMode, Charging
-from .models.charging_history import ChargingHistory
+from .models.charging_history import (
+    ChargingHistory,
+    ChargingStatistics,
+    ChargingStatisticsFilterOption,
+    ChargingStatisticsRequest,
+)
 from .models.chargingprofiles import ChargingProfiles
 from .models.common import Vin
 from .models.departure import DepartureInfo, DepartureTimer
@@ -155,6 +165,27 @@ class RestApi:
     async def _make_put_request(self, url: str, json: dict | None = None) -> str:
         return await self._make_request(url=url, method="PUT", json=json)
 
+    async def _make_charging_post_request(self, path: str, json: dict | None = None) -> str:
+        """POST to the cariad charging service. Path is appended to BASE_URL_CHARGING."""
+        url = f"{BASE_URL_CHARGING}/{path.lstrip('/')}"
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT_IN_SECONDS):
+                async with self.session.request(
+                    method="POST",
+                    url=url,
+                    headers=await self._headers(),
+                    json=json,
+                ) as response:
+                    await response.text()
+                    response.raise_for_status()
+                    return await response.text()
+        except TimeoutError:  # pragma: no cover
+            _LOGGER.exception("Timeout while sending POST request to %s", url)
+            raise
+        except ClientResponseError as err:  # pragma: no cover
+            _LOGGER.exception("Invalid status for POST request to %s: %d", url, err.status)
+            raise
+
     async def verify_spin(self, spin: str, anonymize: bool = False) -> GetEndpointResult[Spin]:
         """Verify SPIN."""
         url = "/v1/spin/verify"
@@ -224,6 +255,33 @@ class RestApi:
             anonymization_fn=anonymize_info,
         )
         result = self._deserialize(raw, ChargingHistory.from_json)
+        return GetEndpointResult(url=url, raw=raw, result=result)
+
+    async def get_charging_statistics(
+        self,
+        vin: str,
+        start: datetime,
+        end: datetime,
+    ) -> GetEndpointResult[ChargingStatistics]:
+        """Retrieve charging session statistics for the specified vehicle via the cariad endpoint.
+
+        Replaces the legacy GET /v1/charging/{vin}/history endpoint which stopped returning
+        new sessions after a certain date.
+        """
+        url = f"{BASE_URL_CHARGING}/charging_statistics"
+        request = ChargingStatisticsRequest(
+            started_after=start.date(),
+            started_before=end.date(),
+            selected_filter_options=[ChargingStatisticsFilterOption(filter_type="VEHICLE", id=vin)],
+        )
+        raw = self.process_json(
+            data=await self._make_charging_post_request(
+                "charging_statistics", json=request.to_dict()
+            ),
+            anonymize=False,
+            anonymization_fn=anonymize_info,
+        )
+        result = self._deserialize(raw, ChargingStatistics.from_json)
         return GetEndpointResult(url=url, raw=raw, result=result)
 
     async def get_status(self, vin: str, anonymize: bool = False) -> GetEndpointResult[Status]:

--- a/tests/fixtures/other/charging-statistics.json
+++ b/tests/fixtures/other/charging-statistics.json
@@ -1,0 +1,57 @@
+{
+    "monthSections": [
+        {
+            "title": "May 2026",
+            "entries": [
+                {
+                    "details": {
+                        "sessionId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                        "chargingPowerType": "DC",
+                        "formattedTotalEnergy": "~ 17 kWh",
+                        "formattedChargingStartTime": "15.05.26 08:30",
+                        "formattedChargingEndTime": "15.05.26 09:05",
+                        "formattedTotalChargingTime": "0h 35min",
+                        "formattedActiveChargingTime": "0h 33min",
+                        "formattedStartSoc": "22%",
+                        "formattedEndSoc": "65%",
+                        "isActiveSession": false
+                    }
+                },
+                {
+                    "details": {
+                        "sessionId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                        "chargingPowerType": "AC",
+                        "formattedTotalEnergy": "~ 42 kWh",
+                        "formattedChargingStartTime": "10.05.26 22:15",
+                        "formattedChargingEndTime": "11.05.26 06:30",
+                        "formattedTotalChargingTime": "8h 15min",
+                        "formattedActiveChargingTime": "7h 50min",
+                        "formattedStartSoc": "18%",
+                        "formattedEndSoc": "100%",
+                        "isActiveSession": false
+                    }
+                }
+            ]
+        },
+        {
+            "title": "April 2026",
+            "entries": [
+                {
+                    "details": {
+                        "sessionId": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+                        "chargingPowerType": "DC",
+                        "formattedTotalEnergy": "~ 25 kWh",
+                        "formattedChargingStartTime": "28.04.26 14:00",
+                        "formattedChargingEndTime": "28.04.26 14:35",
+                        "formattedTotalChargingTime": "0h 35min",
+                        "formattedActiveChargingTime": "0h 34min",
+                        "formattedStartSoc": "30%",
+                        "formattedEndSoc": "80%",
+                        "isActiveSession": false
+                    }
+                }
+            ]
+        }
+    ],
+    "csvFile": "c2Vzc2lvbklkLHN0YXJ0VGltZSxlbmRUaW1lLGVuZXJneUluS1dILGN1cnJlbnRUeXBl"
+}

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -398,15 +398,11 @@ async def test_charging_statistics(
     assert len(result.month_sections) == len(data["monthSections"])
 
     all_entries = [e for s in result.month_sections for e in s.entries]
-    assert len(all_entries) == 3
+    assert len(all_entries) == sum(len(s["entries"]) for s in data["monthSections"])
 
     first = all_entries[0].details
     assert str(first.session_id) == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-    assert first.charging_start_time is not None
-    assert first.charging_start_time.year == 2026
-    assert first.charging_start_time.month == 5
-    assert first.charging_start_time.day == 15
-    assert first.charging_start_time.tzinfo is None  # user-local, no tz
+    assert first.charging_start_time == datetime(2026, 5, 15, 8, 30)  # noqa: DTZ001
     assert result.csv_file == data["csvFile"]
 
 

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -371,6 +371,45 @@ async def test_charging_history(
         assert len(get_charging_history.periods) > 0
 
 
+@pytest.fixture(name="charging_statistics_fixture")
+def load_charging_statistics() -> str:
+    """Load charging statistics fixture."""
+    with FIXTURES_DIR.joinpath("other/charging-statistics.json").open() as file:
+        return file.read()
+
+
+@pytest.mark.asyncio
+async def test_charging_statistics(
+    charging_statistics_fixture: str, myskoda: MySkoda, responses: aioresponses
+) -> None:
+    """Unit test for MySkoda.get_charging_statistics()."""
+    target_vin = "TMBJM0CKV1N12345"
+    start = datetime(2026, 4, 1, tzinfo=UTC)
+    end = datetime(2026, 5, 18, tzinfo=UTC)
+
+    responses.post(
+        url="https://prod.emea.mobile.charging.cariad.digital/charging_statistics",
+        body=charging_statistics_fixture,
+    )
+
+    result = await myskoda.get_charging_statistics(target_vin, start, end)
+
+    data = json.loads(charging_statistics_fixture)
+    assert len(result.month_sections) == len(data["monthSections"])
+
+    all_entries = [e for s in result.month_sections for e in s.entries]
+    assert len(all_entries) == 3
+
+    first = all_entries[0].details
+    assert str(first.session_id) == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    assert first.charging_start_time is not None
+    assert first.charging_start_time.year == 2026
+    assert first.charging_start_time.month == 5
+    assert first.charging_start_time.day == 15
+    assert first.charging_start_time.tzinfo is None  # user-local, no tz
+    assert result.csv_file == data["csvFile"]
+
+
 @pytest.fixture(name="spin_statuses")
 def load_spin_status() -> list[str]:
     """Load spin-status fixture."""


### PR DESCRIPTION
Add `ChargingStatistics` models, a REST API method that POSTs to the cariad charging service, a public `MySkoda.get_charging_statistics()` method, CLI command, and test fixture.

Fixes #573