### PR TITLE
feat: implement FCM refresh within MySkodaMqttClient

### DIFF
--- a/myskoda/const.py
+++ b/myskoda/const.py
@@ -25,7 +25,6 @@ FIREBASE_SENDER_ID = "678067506455"
 MYSKODA_APP_VERSION = "8.12.0"
 MYSKODA_APP_VERSION_CODE = "260430001"
 
-
 MQTT_OPERATION_TIMEOUT = 10 * 60  #  10 minutes
 MQTT_OPERATION_TOPICS = [
     "air-conditioning/set-air-conditioning-at-unlock",
@@ -72,10 +71,18 @@ MQTT_ACCOUNT_EVENT_TOPICS = [
 ]
 MQTT_KEEPALIVE = 60
 MQTT_RECONNECT_DELAY = 5
-MQTT_MAX_RECONNECT_DELAY = 600
+MQTT_MAX_RECONNECT_DELAY = 120
 MQTT_FAST_RETRY = 10
-MAX_RETRIES = 5
+# Maximum time (seconds) MySkodaMqttClient.connect() will block waiting for the
+# initial subscription before raising.
+MQTT_CONNECT_TIMEOUT = 600
+# Minimum time (seconds) that must elapse between two FCM token refreshes
+# triggered by MQTT auth failures. The MySkoda broker can take a while to start
+# accepting a newly registered token, so we throttle to avoid spamming new
+# registrations during that window.
+MQTT_MIN_FCM_REFRESH_INTERVAL = 120
 
+MAX_RETRIES = 5
 
 CACHE_USER_ENDPOINT_IN_HOURS = 6
 CACHE_VEHICLE_HEALTH_IN_HOURS = 6

--- a/myskoda/mqtt.py
+++ b/myskoda/mqtt.py
@@ -12,7 +12,7 @@ import ssl
 import struct
 import time
 import uuid
-from collections.abc import AsyncIterator, Callable, Coroutine
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
 from random import uniform
 from types import TracebackType
 from typing import Any, Protocol, Self, cast
@@ -20,15 +20,18 @@ from typing import Any, Protocol, Self, cast
 import aiomqtt
 from paho.mqtt.packettypes import PacketTypes
 from paho.mqtt.properties import Properties
+from paho.mqtt.reasoncodes import ReasonCode
 
 from .auth.authorization import Authorization
 from .const import (
     MQTT_ACCOUNT_EVENT_TOPICS,
     MQTT_BROKER_HOST,
     MQTT_BROKER_PORT,
+    MQTT_CONNECT_TIMEOUT,
     MQTT_FAST_RETRY,
     MQTT_KEEPALIVE,
     MQTT_MAX_RECONNECT_DELAY,
+    MQTT_MIN_FCM_REFRESH_INTERVAL,
     MQTT_OPERATION_TOPICS,
     MQTT_RECONNECT_DELAY,
     MQTT_SERVICE_EVENT_TOPICS,
@@ -38,6 +41,30 @@ from .models.event import BaseEvent, OperationEvent, OperationName, OperationSta
 
 _LOGGER = logging.getLogger(__name__)
 TOPIC_RE = re.compile("^(.*?)/(.*?)/(.*?)/(.*?)$")
+
+# MQTT CONNACK reason codes that indicate the FCM-derived TOTP credential was
+# rejected. Mixing v3.1.1 return codes and MQTTv5 reason codes is intentional;
+# the underlying paho client may surface either depending on protocol level.
+_AUTH_FAILURE_REASON_CODES: frozenset[int] = frozenset(
+    {
+        4,  # v3.1.1: Bad username or password
+        5,  # v3.1.1: Not authorised
+        0x86,  # v5: Bad User Name or Password
+        0x87,  # v5: Not authorized
+        0x8C,  # v5: Bad authentication method
+    }
+)
+
+
+def _is_auth_failure(exc: BaseException) -> bool:
+    """Return True if exc is an MQTT error caused by credential rejection."""
+    if not isinstance(exc, aiomqtt.MqttCodeError):
+        return False
+    if isinstance(exc.rc, ReasonCode):
+        return exc.rc.value in _AUTH_FAILURE_REASON_CODES
+    if isinstance(exc.rc, int):
+        return exc.rc in _AUTH_FAILURE_REASON_CODES
+    return False
 
 
 def _create_ssl_context() -> ssl.SSLContext:
@@ -143,7 +170,24 @@ class AioMqttClientWrapper(aiomqtt.Client):
         return str(code % (10**6)).zfill(6)
 
 
+class GetFcmToken(Protocol):
+    def __call__(self, force_refresh: bool = False) -> Awaitable[str]: ...  # noqa: D102
+
+
 class MySkodaMqttClient:
+    """A custom MQTT Client for MySkoda.
+
+    Connects to the MQTT broker and allows MySkoda to receive callbacks on MQTT events.
+
+    Args:
+        authorization: An authenticated `Authorization` instance with a `get_access_token`
+                       method returning a current access token.
+        refresh_fcm_token: An async function returning a current and registered FCM token.
+        mqtt_client: A custom `aiomqtt.Client` subclass instance with additional methods to
+                     update connection credentials and properties.
+        ssl_context: An `ssl.SSLContext`
+    """
+
     user_id: str | None
     vehicle_vins: list[str]
     _callbacks: list[Callable[[BaseEvent], Coroutine[Any, Any, None]]]
@@ -152,12 +196,11 @@ class MySkodaMqttClient:
     def __init__(
         self,
         authorization: Authorization,
-        fcm_token: str,
+        refresh_fcm_token: GetFcmToken,
         mqtt_client: AbstractMqttClientWrapper | None = None,
         ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         self.authorization = authorization
-        self.fcm_token = fcm_token
         self.vehicle_vins = []
         self.mqtt_client = mqtt_client
         if self.mqtt_client is None:
@@ -178,14 +221,35 @@ class MySkodaMqttClient:
         self._running = False
         self._subscribed = asyncio.Event()
         self._reconnect_delay = MQTT_RECONNECT_DELAY
+        self._fcm_token = None
+        self._refresh_fcm_token = refresh_fcm_token
+        # Monotonic timestamp of the last successful FCM refresh; used to throttle.
+        self._last_fcm_refresh_at: float | None = None
 
-    async def connect(self, user_id: str, vehicle_vins: list[str]) -> None:
-        """Connect to the MQTT broker and listen for messages for the given user_id and VINs."""
+    async def connect(
+        self,
+        user_id: str,
+        vehicle_vins: list[str],
+        connect_timeout: float = MQTT_CONNECT_TIMEOUT,
+    ) -> None:
+        """Connect to the MQTT broker and listen for messages for the given user_id and VINs.
+
+        Blocks until the initial subscription succeeds or `connect_timeout` seconds elapse.
+        On timeout the background reconnect loop is cancelled and a `TimeoutError` is raised
+        so the caller can decide what to do.
+        """
         _LOGGER.info("Connecting to MQTT with %s/%s", user_id, vehicle_vins)
         self.user_id = user_id
         self.vehicle_vins = vehicle_vins
         self._listener_task = asyncio.create_task(self._connect_and_listen())
-        await self._subscribed.wait()
+        try:
+            async with asyncio.timeout(connect_timeout):
+                await self._subscribed.wait()
+        except TimeoutError as exc:
+            msg = f"MQTT connect did not complete within {connect_timeout}s"
+            _LOGGER.warning(msg)
+            await self.disconnect()
+            raise TimeoutError(msg) from exc
 
     async def disconnect(self) -> None:
         """Cancel listener task and set self_running to False, causing the listen loop to end."""
@@ -214,11 +278,13 @@ class MySkodaMqttClient:
         Reconnect loop based on https://github.com/empicano/aiomqtt/blob/main/docs/reconnection.md.
 
         Re-fetch and update the authorization token on every try.
+        Re-fetch FCM token every MQTT_MIN_FCM_REFRESH_INTERVAL.
         """
         _LOGGER.debug("Starting _connect_and_listen")
         self._running = True
         retry_count = 0  # Track the number of retries
         self._reconnect_delay = MQTT_RECONNECT_DELAY  # Initial delay for backoff
+        self._fcm_token = await self._refresh_fcm_token()
         while self._running:
             try:
                 assert self.mqtt_client is not None
@@ -226,7 +292,7 @@ class MySkodaMqttClient:
                 self.mqtt_client.update_username_password(
                     username=self.user_id or "android-app", password=password
                 )
-                self.mqtt_client.set_connect_properties(fcm_token=self.fcm_token)
+                self.mqtt_client.set_connect_properties(fcm_token=self._fcm_token)
                 async with self.mqtt_client as client:
                     _LOGGER.info("Connected to MQTT")
                     _LOGGER.debug("using MQTT client %s", client)
@@ -249,18 +315,48 @@ class MySkodaMqttClient:
                         self._on_message(message)
             except aiomqtt.MqttError as exc:
                 retry_count += 1
-                _LOGGER.info(
-                    "Connection lost (%s); reconnecting in %ss", exc, self._reconnect_delay
-                )
+                _LOGGER.info("Connection failed (%s); retrying in %ss", exc, self._reconnect_delay)
                 await asyncio.sleep(self._reconnect_delay)
-                if (
-                    retry_count > MQTT_FAST_RETRY
-                    and self._reconnect_delay < MQTT_MAX_RECONNECT_DELAY
-                ):  # first x retries are not exponential
-                    self._reconnect_delay *= 2
-                    self._reconnect_delay += uniform(0, 1)  # noqa: S311
-                    self._reconnect_delay = min(self._reconnect_delay, MQTT_MAX_RECONNECT_DELAY)
-                    _LOGGER.debug("Increased reconnect backoff to %s", self._reconnect_delay)
+                self._increase_reconnect_backoff(retry_count)
+                if _is_auth_failure(exc):
+                    await self._refresh_fcm_token_after_auth_failure()
+
+    def _increase_reconnect_backoff(self, retry_count: int) -> None:
+        """Exponentially grow `self._reconnect_delay` after the fast-retry window."""
+        if retry_count <= MQTT_FAST_RETRY or self._reconnect_delay >= MQTT_MAX_RECONNECT_DELAY:
+            return
+        self._reconnect_delay *= 2
+        self._reconnect_delay += uniform(0, 1)  # noqa: S311
+        self._reconnect_delay = min(self._reconnect_delay, MQTT_MAX_RECONNECT_DELAY)
+        _LOGGER.debug("Increased reconnect backoff to %s", self._reconnect_delay)
+
+    async def _refresh_fcm_token_after_auth_failure(self) -> None:
+        """Refresh the FCM token after an MQTT auth failure.
+
+        Throttled to at most one refresh per `MQTT_MIN_FCM_REFRESH_INTERVAL` seconds: the
+        MySkoda broker may take a while to start accepting a newly registered token, so
+        repeated auth failures within that window must not trigger fresh registrations.
+        """
+        loop_time = asyncio.get_event_loop().time
+        now = loop_time()
+        if self._last_fcm_refresh_at is not None:
+            elapsed = now - self._last_fcm_refresh_at
+            if elapsed < MQTT_MIN_FCM_REFRESH_INTERVAL:
+                _LOGGER.debug(
+                    "Skipping FCM refresh: only %.1fs since last refresh (min %ss)",
+                    elapsed,
+                    MQTT_MIN_FCM_REFRESH_INTERVAL,
+                )
+                return
+        try:
+            new_token = await self._refresh_fcm_token(force_refresh=True)
+        except Exception as refresh_exc:  # noqa: BLE001
+            _LOGGER.warning("Failed to refresh FCM token after MQTT auth failure: %s", refresh_exc)
+            return
+
+        self._last_fcm_refresh_at = loop_time()
+        _LOGGER.info("Refreshed FCM token after MQTT auth failure")
+        self._fcm_token = new_token
 
     def _on_message(self, msg: aiomqtt.Message) -> None:
         """Deserialize received MQTT message and emit Event to subscribed callbacks."""

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -193,20 +193,31 @@ class MySkoda:
         self._mqtt_enabled = mqtt_enabled
 
     async def enable_mqtt(self, fcm_token: str | None = None) -> None:
-        """If MQTT was not enabled when initializing MySkoda, enable it manually and connect."""
+        """If MQTT was not enabled when initializing MySkoda, enable it manually and connect.
+
+        Raises:
+            aiomqtt.MqttError: if the initial MQTT subscription does not complete within
+                MQTT_CONNECT_TIMEOUT seconds. The background reconnect loop is torn down
+                and `self.mqtt` is reset to None so callers can safely retry.
+        """
         self._mqtt_enabled = True
         if not self.mqtt:
-            self.fcm_token = fcm_token or self.fcm_token or await self.get_and_register_fcm_token()
+            self.fcm_token = fcm_token or self.fcm_token
             self.mqtt = MySkodaMqttClient(
                 authorization=self.authorization,
-                fcm_token=self.fcm_token,
+                refresh_fcm_token=self._get_fcm_token,
                 ssl_context=self.ssl_context,
             )
 
         self.mqtt.subscribe(self._on_mqtt_event)
         self.user = await self.get_user()
         vehicles = await self.list_vehicle_vins()
-        await self.mqtt.connect(self.user.id, vehicles)
+        try:
+            await self.mqtt.connect(self.user.id, vehicles)
+        except Exception:
+            # Ensure callers see a clean "not connected" state on failure so they can retry.
+            self.mqtt = None
+            raise
 
     async def connect(
         self,
@@ -1103,12 +1114,15 @@ class MySkoda:
                 background_tasks.add(task)
                 task.add_done_callback(background_tasks.discard)
 
-    async def get_and_register_fcm_token(self) -> str:
+    async def _get_fcm_token(self, force_refresh: bool = False) -> str:
         """Get FCM Token from Google and register it with MySkoda.
 
         Returns:
             The new FCM Token.
         """
+        if self.fcm_token and not force_refresh:
+            return self.fcm_token
+
         fcm_token = await self.firebase.get_fcm_token()
         await self.rest_api.register_fcm_token(fcm_token=fcm_token)
         self.fcm_token = fcm_token

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from contextlib import AbstractAsyncContextManager
 from pathlib import Path
 from socket import socket
 from types import TracebackType
-from typing import Any
+from typing import Any, Self
 from unittest.mock import AsyncMock
 
 import aiomqtt
@@ -82,11 +82,28 @@ class FakeMqttClientWrapper(AbstractAsyncContextManager):
 
     Can be initiatlized with a list of aiomqtt.Message's which will be available immediatally.
     Additional messages can be injected later using set_messages().
+
+    Pass `enter_exceptions` (a list of exceptions or None entries) to script failures from
+    `__aenter__`. Each call pops the next entry: a non-None exception is raised, None means
+    "enter normally". Useful for simulating reconnect-loop behavior in MySkodaMqttClient.
     """
 
-    def __init__(self, messages: list[aiomqtt.Message]) -> None:
+    def __init__(
+        self,
+        messages: list[aiomqtt.Message],
+        enter_exceptions: list[BaseException | None] | None = None,
+    ) -> None:
         self._aiter = SimpleAsyncIterator(messages)
         self.connect_properties_fcm_token: str | None = None
+        self._enter_exceptions: list[BaseException | None] = list(enter_exceptions or [])
+        self.set_connect_properties_calls: list[str] = []
+
+    async def __aenter__(self) -> Self:
+        if self._enter_exceptions:
+            exc = self._enter_exceptions.pop(0)
+            if exc is not None:
+                raise exc
+        return self
 
     async def __aexit__(
         self,
@@ -111,6 +128,7 @@ class FakeMqttClientWrapper(AbstractAsyncContextManager):
 
     def set_connect_properties(self, fcm_token: str) -> None:
         self.connect_properties_fcm_token = fcm_token
+        self.set_connect_properties_calls.append(fcm_token)
 
 
 @pytest.fixture
@@ -128,12 +146,13 @@ def fake_mqtt_client_wrapper() -> FakeMqttClientWrapper:
 
 @pytest.fixture
 async def myskoda_mqtt_client(
-    fake_authorization: FakeAuthorization, fake_mqtt_client_wrapper: FakeMqttClientWrapper
+    fake_authorization: FakeAuthorization,
+    fake_mqtt_client_wrapper: FakeMqttClientWrapper,
 ) -> AsyncIterator[MySkodaMqttClient]:
     """Return a MySkodaMqttClient instance to use in tests."""
     mqtt_client = MySkodaMqttClient(
         authorization=fake_authorization,
-        fcm_token="test-fcm-token",  # noqa: S106
+        refresh_fcm_token=AsyncMock(return_value="test-fcm-token"),
         mqtt_client=fake_mqtt_client_wrapper,
     )
     yield mqtt_client

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -4,10 +4,13 @@ import asyncio
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import ANY, patch
+from typing import Self
+from unittest.mock import ANY, AsyncMock, patch
 
 import aiomqtt
 import pytest
+from paho.mqtt.packettypes import PacketTypes
+from paho.mqtt.reasoncodes import ReasonCode
 
 from myskoda.anonymize import USER_ID, VIN
 from myskoda.models.charging import (
@@ -43,7 +46,7 @@ from myskoda.models.event import (
     VehicleEventWarningBatterylevel,
 )
 from myskoda.models.vehicle_ignition_status import IgnitionStatus
-from myskoda.mqtt import MySkodaMqttClient
+from myskoda.mqtt import MySkodaMqttClient, _is_auth_failure
 from myskoda.myskoda import MySkoda
 
 from .conftest import FakeMqttClientWrapper
@@ -58,18 +61,172 @@ async def connected_mqtt_client(myskoda_mqtt_client: MySkodaMqttClient) -> MySko
     return myskoda_mqtt_client
 
 
-def test_set_connect_properties_uses_constructor_fcm_token() -> None:
-    fake_mqtt_client = FakeMqttClientWrapper(messages=[])
-    mqtt_client = MySkodaMqttClient(
-        authorization=ANY,
-        fcm_token="fcm-token",  # noqa: S106
-        mqtt_client=fake_mqtt_client,
+@pytest.mark.parametrize(
+    ("rc", "expected"),
+    [
+        (5, True),  # v3.1.1 not authorised
+        (4, True),  # v3.1.1 bad username/password
+        (0x87, True),  # v5 not authorized as raw int
+        (
+            ReasonCode(packetType=PacketTypes.CONNACK, identifier=0x87),
+            True,
+        ),  # v5 not authorized as ReasonCode
+        (
+            ReasonCode(packetType=PacketTypes.CONNACK, identifier=0x86),
+            True,
+        ),  # v5 bad credentials
+        (3, False),  # v3.1.1 server unavailable
+        (None, False),
+    ],
+)
+def test_is_auth_failure(rc: int | ReasonCode | None, expected: bool) -> None:
+    exc = aiomqtt.MqttCodeError(rc, "boom")
+    assert _is_auth_failure(exc) is expected
+
+
+def test_is_auth_failure_non_code_error() -> None:
+    assert _is_auth_failure(aiomqtt.MqttError("transport boom")) is False
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_raises_and_cancels_listener(fake_authorization: object) -> None:
+    """If the broker never accepts CONNECT, connect() must raise within the timeout."""
+    # Wrapper hangs forever on __aenter__ — we never reach subscribe -> never set _subscribed.
+    enter_started = asyncio.Event()
+
+    class HangingWrapper(FakeMqttClientWrapper):
+        async def __aenter__(self) -> Self:
+            enter_started.set()
+            await asyncio.Event().wait()  # block forever
+            return self  # pragma: no cover
+
+    wrapper = HangingWrapper(messages=[])
+    client = MySkodaMqttClient(
+        authorization=fake_authorization,  # type: ignore[arg-type]
+        refresh_fcm_token=AsyncMock(return_value="test-fcm-token"),
+        mqtt_client=wrapper,
     )
 
-    with patch("time.time", return_value=60):
-        fake_mqtt_client.set_connect_properties(mqtt_client.fcm_token)
+    with pytest.raises(aiomqtt.MqttError):
+        await client.connect(user_id="1234", vehicle_vins=["VIN"], connect_timeout=0.05)
 
-    assert fake_mqtt_client.connect_properties_fcm_token == "fcm-token"  # noqa: S105
+    assert enter_started.is_set()
+    # Listener task must be torn down so the next connect() attempt starts cleanly.
+    assert client._listener_task is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_triggers_fcm_refresh(fake_authorization: object) -> None:
+    """An MQTT auth failure must call refresh_fcm_token and use the new token next attempt."""
+    auth_error = aiomqtt.MqttCodeError(
+        ReasonCode(packetType=PacketTypes.CONNACK, identifier=0x87), "not authorized"
+    )
+    wrapper = FakeMqttClientWrapper(messages=[], enter_exceptions=[auth_error, None])
+
+    expected_refresh_calls = 2
+    refresh = AsyncMock(side_effect=["old-fcm-token", "new-fcm-token"])
+    client = MySkodaMqttClient(
+        authorization=fake_authorization,  # type: ignore[arg-type]
+        refresh_fcm_token=refresh,
+        mqtt_client=wrapper,
+    )
+
+    # Reduce backoff so the test doesn't sleep 5s between the failed and successful attempts.
+    with patch("myskoda.mqtt.MQTT_RECONNECT_DELAY", 0):
+        client._reconnect_delay = 0  # noqa: SLF001
+        await client.connect(user_id="1234", vehicle_vins=["VIN"], connect_timeout=2)
+
+    assert refresh.await_count == expected_refresh_calls
+    assert client._fcm_token == "new-fcm-token"  # noqa: S105, SLF001
+    # set_connect_properties is invoked once per (re)connect attempt with the current token.
+    assert wrapper.set_connect_properties_calls == ["old-fcm-token", "new-fcm-token"]
+    await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_repeated_auth_failures_are_throttled(
+    fake_authorization: object,
+) -> None:
+    """Two auth failures inside MQTT_MIN_FCM_REFRESH_INTERVAL must only refresh once."""
+    auth_error = aiomqtt.MqttCodeError(
+        ReasonCode(packetType=PacketTypes.CONNACK, identifier=0x87), "not authorized"
+    )
+    # Two auth failures in a row, then a successful connect.
+    wrapper = FakeMqttClientWrapper(messages=[], enter_exceptions=[auth_error, auth_error, None])
+
+    expected_refresh_calls = 2
+    refresh = AsyncMock(side_effect=["old-fcm-token", "new-fcm-token"])
+    client = MySkodaMqttClient(
+        authorization=fake_authorization,  # type: ignore[arg-type]
+        refresh_fcm_token=refresh,
+        mqtt_client=wrapper,
+    )
+
+    # Force throttle window large so the second failure is suppressed regardless of timing.
+    with (
+        patch("myskoda.mqtt.MQTT_RECONNECT_DELAY", 0),
+        patch("myskoda.mqtt.MQTT_MIN_FCM_REFRESH_INTERVAL", 3600),
+    ):
+        client._reconnect_delay = 0  # noqa: SLF001
+        await client.connect(user_id="1234", vehicle_vins=["VIN"], connect_timeout=2)
+
+    assert refresh.await_count == expected_refresh_calls
+    assert client._fcm_token == "new-fcm-token"  # noqa: S105, SLF001
+    await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_refreshes_again_after_throttle_window(
+    fake_authorization: object,
+) -> None:
+    """Once the throttle window elapses, a new auth failure must trigger another refresh."""
+    auth_error = aiomqtt.MqttCodeError(
+        ReasonCode(packetType=PacketTypes.CONNACK, identifier=0x87), "not authorized"
+    )
+    wrapper = FakeMqttClientWrapper(messages=[], enter_exceptions=[auth_error, auth_error, None])
+
+    expected_refresh_calls = 3
+    refresh = AsyncMock(side_effect=["old-fcm-token", "fcm-token-1", "fcm-token-2"])
+    client = MySkodaMqttClient(
+        authorization=fake_authorization,  # type: ignore[arg-type]
+        refresh_fcm_token=refresh,
+        mqtt_client=wrapper,
+    )
+
+    with (
+        patch("myskoda.mqtt.MQTT_RECONNECT_DELAY", 0),
+        patch("myskoda.mqtt.MQTT_MIN_FCM_REFRESH_INTERVAL", 0),
+    ):
+        client._reconnect_delay = 0  # noqa: SLF001
+        await client.connect(user_id="1234", vehicle_vins=["VIN"], connect_timeout=2)
+
+    assert refresh.await_count == expected_refresh_calls
+    assert client._fcm_token == "fcm-token-2"  # noqa: S105, SLF001
+    await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_non_auth_failure_does_not_refresh_fcm(
+    fake_authorization: object,
+) -> None:
+    """Transport errors must NOT trigger an FCM refresh."""
+    transport_error = aiomqtt.MqttError("connection refused")
+    wrapper = FakeMqttClientWrapper(messages=[], enter_exceptions=[transport_error, None])
+
+    refresh = AsyncMock(side_effect=["old-fcm-token", "should-not-be-used"])
+    client = MySkodaMqttClient(
+        authorization=fake_authorization,  # type: ignore[arg-type]
+        refresh_fcm_token=refresh,
+        mqtt_client=wrapper,
+    )
+
+    with patch("myskoda.mqtt.MQTT_RECONNECT_DELAY", 0):
+        client._reconnect_delay = 0  # noqa: SLF001
+        await client.connect(user_id="1234", vehicle_vins=["VIN"], connect_timeout=2)
+
+    refresh.assert_awaited_once()
+    assert client._fcm_token == "old-fcm-token"  # noqa: S105,  SLF001
+    await client.disconnect()
 
 
 @pytest.mark.asyncio

--- a/tests/test_myskoda.py
+++ b/tests/test_myskoda.py
@@ -85,43 +85,15 @@ async def test_myskoda_enable_mqtt_uses_existing_mqtt_client(
         myskoda.mqtt = myskoda_mqtt_client
         myskoda.get_user = AsyncMock(return_value=type("User", (), {"id": "user-id"})())
         myskoda.list_vehicle_vins = AsyncMock(return_value=["vin"])
-        myskoda.get_and_register_fcm_token = AsyncMock()
+        myskoda._get_fcm_token = AsyncMock()  # noqa: SLF001
 
         await myskoda.enable_mqtt(fcm_token="fcm-token")  # noqa: S106
 
         assert myskoda.mqtt is myskoda_mqtt_client
-        assert myskoda_mqtt_client.fcm_token == "test-fcm-token"  # noqa: S105
-        myskoda.get_and_register_fcm_token.assert_not_awaited()
+        assert myskoda_mqtt_client._fcm_token == "test-fcm-token"  # noqa: S105, SLF001
+        myskoda._get_fcm_token.assert_not_awaited()  # noqa: SLF001
         assert myskoda.user is not None
         assert myskoda.user.id == "user-id"
         assert myskoda_mqtt_client.user_id == "user-id"
         assert myskoda_mqtt_client.vehicle_vins == ["vin"]
         assert fake_mqtt_client_wrapper.connect_properties_fcm_token == "test-fcm-token"  # noqa: S105
-
-
-@pytest.mark.asyncio
-async def test_myskoda_enable_mqtt_creates_mqtt_client_with_cached_fcm_token(
-    fake_mqtt_client_wrapper: FakeMqttClientWrapper,
-) -> None:
-    async with ClientSession() as session:
-        myskoda = MySkoda(session, mqtt_enabled=False)
-        myskoda.fcm_token = "cached-token"  # noqa: S105
-        myskoda.authorization.get_access_token = AsyncMock(return_value="access-token")
-        myskoda.get_user = AsyncMock(return_value=type("User", (), {"id": "user-id"})())
-        myskoda.list_vehicle_vins = AsyncMock(return_value=["vin"])
-        myskoda.get_and_register_fcm_token = AsyncMock()
-
-        myskoda.mqtt = MySkodaMqttClient(
-            authorization=myskoda.authorization,
-            fcm_token=myskoda.fcm_token,
-            mqtt_client=fake_mqtt_client_wrapper,
-        )
-
-        await myskoda.enable_mqtt()
-
-        myskoda.get_and_register_fcm_token.assert_not_awaited()
-        assert myskoda.mqtt is not None
-        assert myskoda.mqtt.fcm_token == "cached-token"  # noqa: S105
-        assert myskoda.mqtt.user_id == "user-id"
-        assert myskoda.mqtt.vehicle_vins == ["vin"]
-        assert fake_mqtt_client_wrapper.connect_properties_fcm_token == "cached-token"  # noqa: S105


### PR DESCRIPTION
FCM refresh was broken because `connect()` would just loop forever and never give the caller an opportunity to update the token.

`MySkodaMqttClient` now takes a callable `refresh_fcm_token` which can be used to get/refresh the FCM token. This allows `MySkodaMqttClient` to determine by itself when to get a new token and works similarly to how `Authorization.get_access_token()` is used to get a current access_token.

`MySkodaMqttClient.connect()` (and thus
`MySkoda.connect()/enable_mqtt()`) now also times out completely after `MQTT_CONNECT_TIMEOUT` (600s) - giving callers a chance to do something.

---

This could be considered breaking because `get_and_register_fcm_token` is no more (and no longer makes sense since we no longer want `MySkoda` users to think about FCM tokens) but I don't think anyone except us (in homeassistant-myskoda, where we'll definitely need to update the code) would be calling that right now.

---

TODO:

- [ ] Update and test in homeassistant-myskoda

---

Tests: I started with an incorrect `tokens.json` and got lucky enough to have the first refresh also keep failing, which shows the reconnect loop waiting for 2m before refreshing the fcm token again.

```
2026-06-05 08:46:21 mac myskoda.mqtt[6544] INFO Connecting to MQTT with REDACTED/['REDACTED']
2026-06-05 08:46:21 mac myskoda.mqtt[6544] DEBUG Starting _connect_and_listen
2026-06-05 08:46:21 mac myskoda.mqtt[6544] DEBUG Sending CONNECT (u1, p1, wr0, wq0, wf0, c1, k60) client_id=b'REDACTED#REDACTED' properties=[UserProperty : [('auth_method', 'totp_v1'), ('auth_credentials', '878443')]]
2026-06-05 08:46:21 mac myskoda.mqtt[6544] DEBUG Received CONNACK (0, Not authorized) properties=[]
2026-06-05 08:46:21 mac myskoda.mqtt[6544] INFO Connection failed ([code:135] Not authorized); retrying in 5s
2026-06-05 08:46:26 mac myskoda.firebase[6544] DEBUG Checkin and register with Android FCM
2026-06-05 08:46:27 mac myskoda.myskoda[6544] DEBUG Trace: POST https://android.clients.google.com/checkin - response: 200 (None bytes) <non-UTF-8 response body>
2026-06-05 08:46:27 mac myskoda.myskoda[6544] DEBUG Trace: POST https://firebaseinstallations.googleapis.com/v1/projects/678 - response: 200 (None bytes) REDACTED
26-06-05 08:46:28 mac myskoda.myskoda[6544] DEBUG Trace: POST https://android.clients.google.com/c2dm/register3 - response: 200 (None bytes) token=REDACTED
2026-06-05 08:46:28 mac myskoda.myskoda[6544] DEBUG Trace: PUT https://mysmob.api.connect.skoda-auto.cz/api/v1/notification - response: 201 (0 bytes) 
2026-06-05 08:46:28 mac myskoda.mqtt[6544] INFO Refreshed FCM token after MQTT auth failure
2026-06-05 08:46:29 mac myskoda.mqtt[6544] DEBUG Sending CONNECT (u1, p1, wr0, wq0, wf0, c1, k60) client_id=b'REDACTED#REDACTED' properties=[UserProperty : [('auth_method', 'totp_v1'), ('auth_credentials', '459438')]]
2026-06-05 08:46:29 mac myskoda.mqtt[6544] DEBUG Received CONNACK (0, Not authorized) properties=[]
2026-06-05 08:46:29 mac myskoda.mqtt[6544] INFO Connection failed ([code:135] Not authorized); retrying in 5s
2026-06-05 08:46:34 mac myskoda.mqtt[6544] DEBUG Skipping FCM refresh: only 5.2s since last refresh (min 120s)
2026-06-05 08:46:34 mac myskoda.mqtt[6544] DEBUG Sending CONNECT (u1, p1, wr0, wq0, wf0, c1, k60) client_id=b'REDACTED#REDACTED' properties=[UserProperty : [('auth_method', 'totp_v1'), ('auth_credentials', '988909')]]
2026-06-05 08:46:34 mac myskoda.mqtt[6544] DEBUG Received CONNACK (0, Not authorized) properties=[]
2026-06-05 08:46:34 mac myskoda.mqtt[6544] INFO Connection failed ([code:135] Not authorized); retrying in 5s
...
2026-06-05 08:47:54 mac myskoda.mqtt[6544] DEBUG Skipping FCM refresh: only 85.1s since last refresh (min 120s)
2026-06-05 08:47:54 mac myskoda.mqtt[6544] DEBUG Sending CONNECT (u1, p1, wr0, wq0, wf0, c1, k60) client_id=b'REDACTED#REDACTED' properties=[UserProperty : [('auth_method', 'totp_v1'), ('auth_credentials', '903819')]]
2026-06-05 08:47:54 mac myskoda.mqtt[6544] DEBUG Received CONNACK (0, Not authorized) properties=[]
2026-06-05 08:47:54 mac myskoda.mqtt[6544] INFO Connection failed ([code:135] Not authorized); retrying in 44.91488591303924s
2026-06-05 08:48:39 mac myskoda.mqtt[6544] DEBUG Increased reconnect backoff to 90.29915912800178
2026-06-05 08:48:39 mac myskoda.firebase[6544] DEBUG Checkin and register with Android FCM
2026-06-05 08:48:39 mac myskoda.myskoda[6544] DEBUG Trace: POST https://android.clients.google.com/checkin - response: 200 (None bytes) <non-UTF-8 response body>
2026-06-05 08:48:39 mac myskoda.myskoda[6544] DEBUG Trace: POST https://firebaseinstallations.googleapis.com/v1/projects/678 - response: 200 (None bytes) REDACTED
2026-06-05 08:48:40 mac myskoda.myskoda[6544] DEBUG Trace: POST https://android.clients.google.com/c2dm/register3 - response: 200 (None bytes) token=REDACTED
2026-06-05 08:48:41 mac myskoda.myskoda[6544] DEBUG Trace: PUT https://mysmob.api.connect.skoda-auto.cz/api/v1/notification - response: 201 (0 bytes) 
2026-06-05 08:48:41 mac myskoda.mqtt[6544] INFO Refreshed FCM token after MQTT auth failure
2026-06-05 08:48:41 mac myskoda.mqtt[6544] DEBUG Sending CONNECT (u1, p1, wr0, wq0, wf0, c1, k60) client_id=b'REDACTED#REDACTED' properties=[UserProperty : [('auth_method', 'totp_v1'), ('auth_credentials', '897348')]]
2026-06-05 08:48:41 mac myskoda.mqtt[6544] DEBUG Received CONNACK (0, Success) properties=[ReceiveMaximum : 32, TopicAliasMaximum : 65535, RetainAvailable : 1, MaximumPacketSize : 1048576, WildcardSubscriptionAvailable : 1, SubscriptionIdentifierAvailable : 1, SharedSubscriptionAvailable : 1]
2026-06-05 08:48:41 mac myskoda.mqtt[6544] INFO Connected to MQTT
2026-06-05 08:48:41 mac myskoda.mqtt[6544] DEBUG using MQTT client <myskoda.mqtt.AioMqttClientWrapper object at 0x108a4e3c0>
2026-06-05 08:48:41 mac myskoda.mqtt[6544] DEBUG Sending SUBSCRIBE (d0, m1) [(b'REDACTED/REDACTED/operation-request/air-conditioning/set-air-conditioning-at-unlock', {QoS=0, noLocal=False, retainAsPublished=False, retainHandling=0})]
2026-06-05 08:48:41 mac myskoda.mqtt[6544] DEBUG Received SUBACK
...
```