### PR TITLE
feat: expose camping mode controls

### DIFF
--- a/myskoda/cli/__init__.py
+++ b/myskoda/cli/__init__.py
@@ -35,10 +35,12 @@ from myskoda.cli.operations import (
     set_windows_heating,
     start_air_conditioning,
     start_auxiliary_heating,
+    start_camping,
     start_ventilation,
     start_window_heating,
     stop_air_conditioning,
     stop_auxiliary_heating,
+    stop_camping,
     stop_ventilation,
     stop_window_heating,
     unlock,
@@ -215,11 +217,13 @@ cli.add_command(single_trip_statistics)
 cli.add_command(software_update_status)
 cli.add_command(start_air_conditioning)
 cli.add_command(start_auxiliary_heating)
+cli.add_command(start_camping)
 cli.add_command(start_ventilation)
 cli.add_command(start_window_heating)
 cli.add_command(status)
 cli.add_command(stop_air_conditioning)
 cli.add_command(stop_auxiliary_heating)
+cli.add_command(stop_camping)
 cli.add_command(stop_ventilation)
 cli.add_command(stop_window_heating)
 cli.add_command(subscribe)

--- a/myskoda/cli/operations.py
+++ b/myskoda/cli/operations.py
@@ -54,6 +54,36 @@ async def stop_air_conditioning(ctx: Context, timeout: float, vin: str) -> None:
 
 
 @click.command()
+@click.option("temperature", "--temperature", type=float, required=True)
+@click.option("timeout", "--timeout", type=float, default=300)
+@click.argument("vin")
+@click.pass_context
+@mqtt_required
+async def start_camping(
+    ctx: Context,
+    temperature: float,
+    timeout: float,  # noqa: ASYNC109
+    vin: str,
+) -> None:
+    """Start camping mode with the provided target temperature in °C."""
+    myskoda: MySkoda = ctx.obj["myskoda"]
+    async with asyncio.timeout(timeout):
+        await myskoda.start_camping(vin, temperature)
+
+
+@click.command()
+@click.option("timeout", "--timeout", type=float, default=300)
+@click.argument("vin")
+@click.pass_context
+@mqtt_required
+async def stop_camping(ctx: Context, timeout: float, vin: str) -> None:  # noqa: ASYNC109
+    """Stop camping mode."""
+    myskoda: MySkoda = ctx.obj["myskoda"]
+    async with asyncio.timeout(timeout):
+        await myskoda.stop_camping(vin)
+
+
+@click.command()
 @click.option("timeout", "--timeout", type=float, default=300)
 @click.argument("vin")
 @click.pass_context

--- a/myskoda/models/air_conditioning.py
+++ b/myskoda/models/air_conditioning.py
@@ -153,6 +153,14 @@ class WindowHeating(DataClassORJSONMixin):
 
 
 @dataclass
+class CampingMode(DataClassORJSONMixin):
+    """Camping mode state."""
+
+    enabled: bool
+    ends_at: datetime | None = field(default=None, metadata=field_options(alias="endsAt"))
+
+
+@dataclass
 class AirConditioning(BaseResponse):
     """Information related to air conditioning."""
 
@@ -194,4 +202,7 @@ class AirConditioning(BaseResponse):
     )
     outside_temperature: OutsideTemperature | None = field(
         default=None, metadata=field_options(alias="outsideTemperature")
+    )
+    camping_mode: CampingMode | None = field(
+        default=None, metadata=field_options(alias="campingMode")
     )

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -759,6 +759,22 @@ class MySkoda:
         await self.rest_api.stop_air_conditioning(vin)
         await future
 
+    async def start_camping(self, vin: Vin, temperature: float) -> None:
+        """Start camping mode with the provided target temperature in °C.
+
+        Camping mode does not emit a dedicated operation event, so this returns
+        once the request is accepted; the new state is reflected on the next poll.
+        """
+        await self.rest_api.start_camping(vin, temperature)
+
+    async def stop_camping(self, vin: Vin) -> None:
+        """Stop camping mode.
+
+        Camping mode does not emit a dedicated operation event, so this returns
+        once the request is accepted; the new state is reflected on the next poll.
+        """
+        await self.rest_api.stop_camping(vin)
+
     async def start_ventilation(self, vin: Vin) -> None:
         """Start the ventilation."""
         future = self._wait_for_operation(OperationName.START_ACTIVE_VENTILATION)

--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -762,18 +762,22 @@ class MySkoda:
     async def start_camping(self, vin: Vin, temperature: float) -> None:
         """Start camping mode with the provided target temperature in °C.
 
-        Camping mode does not emit a dedicated operation event, so this returns
-        once the request is accepted; the new state is reflected on the next poll.
+        Camping has no dedicated operation event; enabling it drives the climate,
+        so we await the regular start-air-conditioning operation.
         """
+        future = self._wait_for_operation(OperationName.START_AIR_CONDITIONING)
         await self.rest_api.start_camping(vin, temperature)
+        await future
 
     async def stop_camping(self, vin: Vin) -> None:
         """Stop camping mode.
 
-        Camping mode does not emit a dedicated operation event, so this returns
-        once the request is accepted; the new state is reflected on the next poll.
+        Camping has no dedicated operation event; disabling it stops the climate,
+        so we await the regular stop-air-conditioning operation.
         """
+        future = self._wait_for_operation(OperationName.STOP_AIR_CONDITIONING)
         await self.rest_api.stop_camping(vin)
+        await future
 
     async def start_ventilation(self, vin: Vin) -> None:
         """Start the ventilation."""

--- a/myskoda/rest_api.py
+++ b/myskoda/rest_api.py
@@ -810,6 +810,21 @@ class RestApi:
             json=json_data,
         )
 
+    async def start_camping(self, vin: str, temperature: float) -> None:
+        """Start camping mode with the provided target temperature in °C."""
+        round_temp = round(temperature * 2) / 2
+        _LOGGER.debug("Starting camping mode for vehicle %s with temperature %.1f", vin, round_temp)
+        json_data = {"temperatureValue": round_temp, "unitInCar": "CELSIUS"}
+        await self._make_post_request(
+            url=f"/v2/air-conditioning/{vin}/camping/start",
+            json=json_data,
+        )
+
+    async def stop_camping(self, vin: str) -> None:
+        """Stop camping mode."""
+        _LOGGER.debug("Stopping camping mode for vehicle %s", vin)
+        await self._make_post_request(url=f"/v2/air-conditioning/{vin}/camping/stop")
+
     async def set_ac_at_unlock(self, vin: str, settings: AirConditioningAtUnlock) -> None:
         """Enable or disable AC at unlock."""
         _LOGGER.debug(

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -19,6 +19,8 @@ def _strip_injected_fields(d: dict) -> None:
     d.pop("timestamp", None)
     if d.get("car_captured_timestamp") is None:
         d.pop("car_captured_timestamp", None)
+    if d.get("camping_mode") is None:
+        d.pop("camping_mode", None)
     for v in d.values():
         if isinstance(v, dict):
             _strip_injected_fields(v)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -936,15 +936,22 @@ async def test_set_preferred_charging(  # noqa: PLR0913
 async def test_start_camping(
     responses: aioresponses,
     myskoda: MySkoda,
+    fake_mqtt_client_wrapper: FakeMqttClientWrapper,
     temperature: float,
     expected: float,
 ) -> None:
-    """Camping mode start posts the bare target-temperature body and does not wait for MQTT."""
+    """Camping mode start posts the bare target-temp body and awaits start-air-conditioning."""
     url = f"{BASE_URL_SKODA}/api/v2/air-conditioning/{VIN}/camping/start"
     responses.post(url=url)
 
-    await myskoda.start_camping(VIN, temperature)
+    future = myskoda.start_camping(VIN, temperature)
 
+    topic = f"{USER_ID}/{VIN}/operation-request/air-conditioning/start-stop-air-conditioning"
+    fake_mqtt_client_wrapper.set_messages(
+        [create_aiomqtt_message(topic=topic, operation="start-air-conditioning")]
+    )
+
+    await future
     responses.assert_called_with(
         url=url,
         method="POST",
@@ -954,13 +961,23 @@ async def test_start_camping(
 
 
 @pytest.mark.asyncio
-async def test_stop_camping(responses: aioresponses, myskoda: MySkoda) -> None:
-    """Camping mode stop posts no body and does not wait for MQTT."""
+async def test_stop_camping(
+    responses: aioresponses,
+    myskoda: MySkoda,
+    fake_mqtt_client_wrapper: FakeMqttClientWrapper,
+) -> None:
+    """Camping mode stop posts no body and awaits stop-air-conditioning."""
     url = f"{BASE_URL_SKODA}/api/v2/air-conditioning/{VIN}/camping/stop"
     responses.post(url=url)
 
-    await myskoda.stop_camping(VIN)
+    future = myskoda.stop_camping(VIN)
 
+    topic = f"{USER_ID}/{VIN}/operation-request/air-conditioning/start-stop-air-conditioning"
+    fake_mqtt_client_wrapper.set_messages(
+        [create_aiomqtt_message(topic=topic, operation="stop-air-conditioning")]
+    )
+
+    await future
     responses.assert_called_with(
         url=url,
         method="POST",

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -929,3 +929,41 @@ async def test_set_preferred_charging(  # noqa: PLR0913
             headers={"authorization": f"Bearer {ACCESS_TOKEN}"},
             json=json_data,
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("temperature", "expected"), [(21.5, 21.5), (23.2, 23.0), (10.01, 10.0)])
+async def test_start_camping(
+    responses: aioresponses,
+    myskoda: MySkoda,
+    temperature: float,
+    expected: float,
+) -> None:
+    """Camping mode start posts the bare target-temperature body and does not wait for MQTT."""
+    url = f"{BASE_URL_SKODA}/api/v2/air-conditioning/{VIN}/camping/start"
+    responses.post(url=url)
+
+    await myskoda.start_camping(VIN, temperature)
+
+    responses.assert_called_with(
+        url=url,
+        method="POST",
+        headers={"authorization": f"Bearer {ACCESS_TOKEN}"},
+        json={"temperatureValue": expected, "unitInCar": "CELSIUS"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_camping(responses: aioresponses, myskoda: MySkoda) -> None:
+    """Camping mode stop posts no body and does not wait for MQTT."""
+    url = f"{BASE_URL_SKODA}/api/v2/air-conditioning/{VIN}/camping/stop"
+    responses.post(url=url)
+
+    await myskoda.stop_camping(VIN)
+
+    responses.assert_called_with(
+        url=url,
+        method="POST",
+        headers={"authorization": f"Bearer {ACCESS_TOKEN}"},
+        json=None,
+    )


### PR DESCRIPTION
In https://github.com/skodaconnect/myskoda/pull/602 the CAMPING_MODE was already introduced. Now we get controls for it.

This adds start_camping/stop_camping methods to RestApi and MySkoda, and a CampingMode model (enabled + endsAt) on the AirConditioning response.

Endpoints (extracted from v8.14.0 of the Android app and verified against my 2023 Enyaq):
- POST /v2/air-conditioning/{vin}/camping/start body {"temperatureValue": 1234, "unitInCar": "CELSIUS"}
- POST /v2/air-conditioning/{vin}/camping/stop  (no body)
- state read from GET /v2/air-conditioning/{vin} -> campingMode.enabled

Camping has no dedicated MQTT operation. Triggering it simply emits the the regular start-stop-air-conditioning event. Tested via wildcard MQTT capture on Home Assistant, with app-initiated camping mode on/off triggers.