### PR TITLE
fix(myskoda): pass start/end as keywords in get_all_charging_sessions

### DIFF
--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -389,7 +389,7 @@ class MySkoda:
 
         request_limit: int = 50
         charging_history = await self.rest_api.get_charging_history(
-            vin, start, end, limit=request_limit
+            vin, start=start, end=end, limit=request_limit
         )
         sessions = extract_sessions(charging_history.result)
         cursor = charging_history.result.next_cursor

--- a/tests/test_myskoda.py
+++ b/tests/test_myskoda.py
@@ -1,14 +1,22 @@
 """Unit tests for myskoda.py."""
 
+import re
+from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
+from urllib.parse import unquote
 
 import pytest
 from aiohttp import ClientSession
+from aioresponses import aioresponses
 
 from myskoda.models.event.operation import OperationEvent, OperationName, OperationStatus
 from myskoda.mqtt import MySkodaMqttClient
 from myskoda.myskoda import MySkoda
+from myskoda.utils import to_iso8601
 from tests.conftest import FakeMqttClientWrapper
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.mark.asyncio
@@ -140,3 +148,32 @@ async def test_process_operation_event_skips_refresh_on_error() -> None:
         await myskoda._process_operation_event(event)  # noqa: SLF001
 
         myskoda.refresh_charging_profiles.assert_not_awaited()
+
+
+async def test_get_all_charging_sessions_applies_date_filters(
+    myskoda: MySkoda, responses: aioresponses
+) -> None:
+    """Regression test that date filters are not sent as a charging history cursor."""
+    start = datetime(2025, 12, 25, tzinfo=UTC)
+    end = datetime(2026, 6, 1, tzinfo=UTC)
+    target_vin = "TMBJM0CKV1N12345"
+    charging_history = FIXTURES_DIR.joinpath("other/charging-history.json").read_text()
+    url = re.compile(
+        rf"https://mysmob\.api\.connect\.skoda-auto\.cz/api/v1/charging/{target_vin}/history\?.*"
+    )
+    responses.get(url=url, body=charging_history)
+
+    sessions = await myskoda.get_all_charging_sessions(target_vin, start=start, end=end)
+
+    history_calls = [
+        (url, req)
+        for (method, url), reqs in responses.requests.items()
+        for req in reqs
+        if method == "GET" and "charging" in str(url) and "history" in str(url)
+    ]
+    assert len(history_calls) >= 1
+    first_url = unquote(unquote(str(history_calls[0][0])))
+    assert f"from={to_iso8601(start)}" in first_url
+    assert f"to={to_iso8601(end)}" in first_url
+    assert "cursor=" not in first_url
+    assert len(sessions) == 3  # noqa: PLR2004


### PR DESCRIPTION
Positional forwarding bound start to the cursor parameter, so the first history request sent cursor=<start_iso> instead of from=/to=, yielding HTTP 500. Add regression test pinning the wire contract.

Closes #595