### PR TITLE
ci: test only last patch version of each HA minor

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: Lint and test
 
 env:
-  MIN_HA: "2025.8.0"
+  MIN_HA: "2026.1.0"
 on:
   push:
   pull_request:
@@ -55,7 +55,10 @@ jobs:
         run: |
           VERSIONS=$(curl -s https://pypi.org/pypi/homeassistant/json | \
             jq -c --arg min "$MIN_HA" \
-              '[.releases | keys[] | select(. >= $min) | select(test("a|b|rc|dev") | not)]')
+              '[.releases | keys[] | select(. >= $min) | select(test("a|b|rc|dev") | not)] |
+               map({minor: (split(".") | .[0:2] | join(".")), patch: (split(".") | .[2] | tonumber), full: .}) |
+               group_by(.minor) |
+               map(max_by(.patch) | .full)')
           echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
           echo "versions: $VERSIONS"
 


### PR DESCRIPTION
Testing every single version makes CI slow, which makes developers sad.

Also bump the minimum version we actually validate to 2026.1

Fixes #624