### PR TITLE
fix: add charging_profiles to default capabilitiesthat are fetched for a vehicle

### DIFF
--- a/myskoda/myskoda.py
+++ b/myskoda/myskoda.py
@@ -312,6 +312,7 @@ class MySkoda:
             CapabilityId.AUXILIARY_HEATING,
             CapabilityId.CHARGING,
             CapabilityId.CHARGING_MEB,
+            CapabilityId.CHARGING_PROFILES,
             CapabilityId.PARKING_POSITION,
             CapabilityId.STATE,
             CapabilityId.TRIP_STATISTICS,


### PR DESCRIPTION
Although the support was added in the other commit, Charging Profiles are not actually fetched when using get_vehicles as the Capability was not listed there. To actually remove the special handling of Charging profiles in the other HA PR completely, this missing feature is still required.