### PR TITLE
feat(models): preserve unknown enum values as pseudo-members

### DIFF
--- a/myskoda/models/common.py
+++ b/myskoda/models/common.py
@@ -1,11 +1,15 @@
 """Common models used in multiple responses."""
 
+import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import cast
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+_LOGGER = logging.getLogger(__name__)
 
 type Vin = str
 
@@ -24,6 +28,34 @@ class CaseInsensitiveStrEnum(StrEnum):
             if member.lower() == value:
                 return member
         return None
+
+
+class LenientStrEnum(CaseInsensitiveStrEnum):
+    """Case-insensitive enum that preserves unrecognized values.
+
+    Values not matching any known member become singleton pseudo-members
+    carrying the raw string, so deserialization keeps working when the API
+    introduces new values and the original data remains visible. A warning
+    is logged for each new value.
+    """
+
+    @classmethod
+    def _missing_(cls, value: object) -> StrEnum | None:
+        """Return a known member, or a pseudo-member preserving the raw value."""
+        if not isinstance(value, str):
+            raise TypeError
+        member = super()._missing_(value)
+        if member is not None:
+            return member
+        existing = cast("StrEnum | None", cls._value2member_map_.get(value))
+        if existing is not None:
+            return existing
+        pseudo = cast("StrEnum", str.__new__(cls, value))
+        pseudo._name_ = "UNKNOWN_" + value.upper()
+        pseudo._value_ = value
+        cls._value2member_map_.setdefault(value, pseudo)
+        _LOGGER.warning("Unknown %s value %r; preserving raw value", cls.__name__, value)
+        return pseudo
 
 
 class OnOffState(StrEnum):

--- a/myskoda/models/software_status.py
+++ b/myskoda/models/software_status.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass, field
 
 from mashumaro import field_options
 
-from .common import BaseResponse, CaseInsensitiveStrEnum
+from .common import BaseResponse, LenientStrEnum
 
 
-class SoftwareStatus(CaseInsensitiveStrEnum):
+class SoftwareStatus(LenientStrEnum):
     NO_UPDATE_AVAILABLE = "NO_UPDATE_AVAILABLE"
     PRE_UPDATE_AVAILABLE = "PRE_UPDATE_AVAILABLE"
     UPDATE_AVAILABLE = "UPDATE_AVAILABLE"
@@ -23,7 +23,3 @@ class SoftwareUpdateStatus(BaseResponse):
     release_notes_url: str | None = field(
         default=None, metadata=field_options(alias="releaseNotesUrl")
     )
-
-
-class UnexpectedSoftwareUpdateStatusError(Exception):
-    pass

--- a/tests/test_case_insensitive_enum.py
+++ b/tests/test_case_insensitive_enum.py
@@ -1,0 +1,57 @@
+"""Tests for lenient enum handling of unknown API values."""
+
+import logging
+
+import pytest
+
+from myskoda.models.charging import ChargingState
+from myskoda.models.software_status import SoftwareStatus, SoftwareUpdateStatus
+
+
+def test_unknown_value_is_preserved_as_pseudo_member() -> None:
+    """An unrecognized value becomes a member carrying the raw string."""
+    member = SoftwareStatus("SOME_FUTURE_STATUS")
+    assert member.value == "SOME_FUTURE_STATUS"
+    assert str(member) == "SOME_FUTURE_STATUS"
+    assert isinstance(member, SoftwareStatus)
+    assert member.name not in SoftwareStatus.__members__
+
+
+def test_unknown_value_pseudo_members_are_singletons() -> None:
+    """The same unknown value always resolves to the same pseudo-member."""
+    assert SoftwareStatus("SOME_FUTURE_STATUS") is SoftwareStatus("SOME_FUTURE_STATUS")
+
+
+def test_unknown_value_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    """A warning is logged when a new value is encountered."""
+    with caplog.at_level(logging.WARNING):
+        SoftwareStatus("LOG_ME_STATUS")
+    assert "LOG_ME_STATUS" in caplog.text
+
+
+def test_case_insensitive_match_still_wins() -> None:
+    """Known values keep matching case-insensitively."""
+    assert SoftwareStatus("update_in_progress") is SoftwareStatus.UPDATE_IN_PROGRESS
+
+
+def test_unrecognized_status_deserializes_without_raising() -> None:
+    """A novel server-side status deserializes and keeps its raw value."""
+    result = SoftwareUpdateStatus.from_json(
+        '{"status":"BRAND_NEW","currentSoftwareVersion":"1.2.3"}'
+    )
+    assert result.status.value == "BRAND_NEW"
+    assert result.status.name not in SoftwareStatus.__members__
+
+
+def test_unknown_status_serializes_raw_value() -> None:
+    """Serializing keeps the raw unknown value."""
+    result = SoftwareUpdateStatus.from_json(
+        '{"status":"BRAND_NEW","currentSoftwareVersion":"1.2.3"}'
+    )
+    assert result.to_dict()["status"] == "BRAND_NEW"
+
+
+def test_enum_without_lenient_base_stays_strict() -> None:
+    """Enums not inheriting LenientStrEnum keep raising on unknown values."""
+    with pytest.raises(ValueError, match="is not a valid"):
+        ChargingState("NOT_A_REAL_STATE")


### PR DESCRIPTION
Add LenientStrEnum, a case-insensitive enum that maps unrecognized values to singleton pseudo-members carrying the raw string and logs a warning, so newly introduced API values no longer break deserialization and the original data remains visible. SoftwareStatus opts in; the dead UnexpectedSoftwareUpdateStatusError is removed. Enums without the lenient base keep the strict behavior.

Potential replacement for #645.

Fixes #641 

Note: quick PoC made with AI Agent. Need to review it myself still.