### PR TITLE
test: use ids for generated test to ease identification of failures

### DIFF
--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -49,6 +49,7 @@ async def test_report_get(
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     parameters = []
+    ids = []
 
     for file in FIXTURES_DIR.glob("**/*.yaml"):
         text = file.read_text(encoding="utf-8")
@@ -59,5 +60,6 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             if not report.success:
                 continue
             parameters.append(report)
+            ids.append(fixture.name + "_" + report.endpoint)
 
-    metafunc.parametrize("report", parameters)
+    metafunc.parametrize("report", parameters, ids=ids)


### PR DESCRIPTION
This change adds readable ids to the tests generated from fixtures. It allows one to easily identify the fixture file/endpoint that is being tested instead of having to figure that out from the stack trace of the failed test.
<img width="344" height="286" alt="pytest_ids" src="https://github.com/user-attachments/assets/c66e2b16-8a31-4820-9918-a410ca518196" />
